### PR TITLE
Added missing "case" and "break" to ARRAY_SET in JNI as Hugh suggested.

### DIFF
--- a/project/android/JNI.cpp
+++ b/project/android/JNI.cpp
@@ -335,6 +335,7 @@ value JObjectToHaxeObject(JNIEnv *env,jobject inObject)
  *
  */
 #define ARRAY_SET(PRIM,JTYPE,CREATE) \
+   case jni##PRIM: \
    { \
       if (len>0) \
       { \
@@ -346,7 +347,8 @@ value JObjectToHaxeObject(JNIEnv *env,jobject inObject)
           } \
           inEnv->Release##PRIM##ArrayElements((JTYPE##Array)inObject,data,JNI_ABORT); \
       } \
-   }
+   }\
+   break;
 
 value JObjectToHaxe(JNIEnv *inEnv,JNIType inType,jobject inObject)
 {


### PR DESCRIPTION
The bug was discovered when I was writing some code to call a Java method the returns Array.
Bug demo:

MainActivity.java:

``` java
package net.onthewings.pong;

public class MainActivity extends org.haxe.nme.GameActivity {
    static public int[] testArray() {
        int intArray[] = {1, 2, 3};
        return intArray;
    }
}
```

TestJNI.hx:

``` haxe
class TestJNI {
    static var _testArray:Dynamic;
    static public function testArray():Array<Int> {
        if (_testArray == null) _testArray = JNI.createStaticMethod("net.onthewings.pong.MainActivity", "testArray", "()[I");
        return _testArray();
    }
}
```

The haxe(NME) side was getting [0,0,0].
This commit fix the bug.
