### PR TITLE
Fixed .gitignore not to ignore everything under the ndll folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 .DS_Store
-ndll/*
+ndll/*/nme.ndll
+ndll/*/nme-debug.ndll
 project/all_objs
 project/obj
+project/vc*.pdb
 tools/command-line/command-line.n
 tools/unit-testing/Export
 tools/installer/mac/*.dmg


### PR DESCRIPTION
Previously, the whole ndll folder was on the .gitignore file. This won't work out because there is many binaries that are not rebuild under this folder (libSDL and libTouchControlOverlay on BlackBerry, libcurl, libcurl_ssl, libjpeg, libpng and libz on iPhone, nekoapi and tls on Linux, tls on Linux64, tls on Mac, and tls as well as the ReplaceVistaIcon utility on Windows).

By changing the ignore pattern to ndll/_/nme-debug.ndll and ndll/_/nme.ndll, only NME ndll files are being ignored.

This patch also prevents the vs100.pdb file from being committed, and all other PDB files for the various versions of Visual Studio.
