### PR TITLE
InstallTool fix: should not remove "/" if lastArgument is only "/"

### DIFF
--- a/tools/command-line/src/InstallTool.hx
+++ b/tools/command-line/src/InstallTool.hx
@@ -277,7 +277,7 @@ class InstallTool {
 			
 			var lastArgument:String = new Path (args[args.length - 1]).toString ();
 			
-			if ((StringTools.endsWith (lastArgument, "/") || StringTools.endsWith (lastArgument, "\\")) && !StringTools.endsWith (lastArgument, ":\\")) {
+			if (((StringTools.endsWith (lastArgument, "/") && lastArgument != "/") || StringTools.endsWith (lastArgument, "\\")) && !StringTools.endsWith (lastArgument, ":\\")) {
 				
 				lastArgument = lastArgument.substr (0, lastArgument.length - 1);
 				


### PR DESCRIPTION
`lastArgument` will become `""` without the check, and `FileSystem.isDirectory (lastArgument)` will be `false`, making the path `nme` wrong...
