### PR TITLE
Auto start the intent when run/test android -air.

### DIFF
--- a/tools/command-line/src/helpers/AIRHelper.hx
+++ b/tools/command-line/src/helpers/AIRHelper.hx
@@ -151,8 +151,9 @@ class AIRHelper {
 	public static function run (workingDirectory:String, debug:Bool):Void {
 		
 		if (target == "android") {
-				
+			
 			AndroidHelper.install (FileSystem.fullPath (workingDirectory) + "/" + defines.get ("APP_FILE") + ".apk");
+			AndroidHelper.run ("air." + defines.get ("APP_PACKAGE") + "/.AppEntry");
 			
 		} else if (target == "ios") {
 			


### PR DESCRIPTION
To match the other targets' run/test behavior, auto start the intent of the app when `nme [run|test] android -air`
