### PR TITLE
Fix for JEASH-28

### DIFF
--- a/jeash/display/DisplayObject.hx
+++ b/jeash/display/DisplayObject.hx
@@ -369,7 +369,7 @@ class DisplayObject extends EventDispatcher, implements IBitmapDrawable
 	}
 
 	private function jeashRender(?inMask:HTMLCanvasElement, ?clipRect:Rectangle) {
-		if (!jeashVisible || (parent == null) || !parent.jeashCombinedVisible) return; 
+		if (!jeashVisible) return;
 
 		var gfx = jeashGetGraphics();
 		if (gfx == null) return;
@@ -455,7 +455,7 @@ class DisplayObject extends EventDispatcher, implements IBitmapDrawable
 	}
 
 	private function jeashGetObjectUnderPoint(point:Point):DisplayObject {
-		if (!jeashVisible || (parent == null) || !parent.jeashCombinedVisible) return null; 
+		if (!visible) return null;
 		var gfx = jeashGetGraphics();
 		if (gfx != null) {
 			var extX = gfx.jeashExtent.x;
@@ -658,9 +658,8 @@ class DisplayObject extends EventDispatcher, implements IBitmapDrawable
 	}
 	private function jeashSetVisible(inValue:Bool) {
 		var gfx = jeashGetGraphics();
-		var drawAsVisible:Bool = (parent != null) &&  inValue && parent.jeashCombinedVisible;
 		if (gfx != null && gfx.jeashSurface != null)
-			Lib.jeashSetSurfaceVisible(gfx.jeashSurface, drawAsVisible ); 
+			Lib.jeashSetSurfaceVisible(gfx.jeashSurface, inValue);
 		jeashVisible = inValue;
 		return visible;
 	}

--- a/jeash/display/DisplayObjectContainer.hx
+++ b/jeash/display/DisplayObjectContainer.hx
@@ -36,7 +36,6 @@ import jeash.Lib;
 class DisplayObjectContainer extends InteractiveObject
 {
 	public var jeashChildren:Array<DisplayObject>;
-	public var jeashCombinedVisible:Bool;
 	public var numChildren(jeashGetNumChildren, never):Int;
 	public var mouseChildren:Bool;
 	public var tabChildren:Bool;
@@ -46,7 +45,6 @@ class DisplayObjectContainer extends InteractiveObject
 		jeashChildren = new Array<DisplayObject>();
 		mouseChildren = true;
 		tabChildren = true;
-		jeashCombinedVisible = true;
 		super();
 		jeashCombinedAlpha = alpha;
 	}
@@ -114,7 +112,6 @@ class DisplayObjectContainer extends InteractiveObject
 
 	override private function jeashAddToStage(newParent:DisplayObjectContainer, ?beforeSibling:DisplayObject) {
 		super.jeashAddToStage(newParent, beforeSibling);
-		jeashCombinedVisible = jeashVisible && newParent.jeashCombinedVisible; 
 		for (child in jeashChildren) {
 			if (child.jeashGetGraphics() == null || !child.jeashIsOnStage()) {
 				child.jeashAddToStage(this);
@@ -323,10 +320,10 @@ class DisplayObjectContainer extends InteractiveObject
 	}
 
 	override private function jeashGetObjectUnderPoint(point:Point) {
+		if (!visible) return null;
 		var l = jeashChildren.length-1;
 		for (i in 0...jeashChildren.length) {
 			var result = jeashChildren[l-i].jeashGetObjectUnderPoint(point);
-		if (!jeashCombinedVisible) return null; 
 			if (result != null)
 				return mouseChildren ? result : this;
 		}
@@ -360,9 +357,8 @@ class DisplayObjectContainer extends InteractiveObject
 
 	override private function jeashSetVisible(visible:Bool) {
 		super.jeashSetVisible(visible);
-		jeashCombinedVisible = parent != null ? jeashVisible && parent.jeashCombinedVisible : jeashVisible; 
 		for (child in jeashChildren) {
-			if (child.jeashIsOnStage()) child.visible = child.visible; // Redraw the child.
+			if (child.jeashIsOnStage()) child.visible = visible;
 		}
 		return visible;
 	}


### PR DESCRIPTION
Hi, this should fix the issue where child DisplayObjects will not respect the alpha property of anything higher up the display list than one level. I attached a test case to the bug report which illustrates the bug. https://haxenme.atlassian.net/browse/JEASH-28

Basically my approach is to keep a merged alpha property in all DisplayObjectContainers so you don't need to manually walk up the display list every time you need to calculate alpha.
