### PR TITLE
Some text field fixes

### DIFF
--- a/browser/text/TextField.hx
+++ b/browser/text/TextField.hx
@@ -542,7 +542,6 @@ class TextField extends InteractiveObject {
 				align_x = Math.round(mWidth)-w;
 				
 			}
-			trace("doing, align_x: "+align_x);
 		}
 		
 		var x_list = new Array<Int>();


### PR DESCRIPTION
I changed mText = inText; to mText=Std.string(inText); in the set_text function in TextField. The parameter is declared as String, so it should be a string there, but apparently it is possible that the underlying javascript variable when the code gets executed is actually a number. This made the mText.split("\n"); call in RebuildText crash. I'm not 100% sure of the origin of this number variable in my app, but I think that some JSON parsing have something to do with it.

I also changed the centering of text in text fields, so it works in _my_ app at least.
