### PR TITLE
Fixes #NME-226.

### DIFF
--- a/browser/display/DisplayObject.hx
+++ b/browser/display/DisplayObject.hx
@@ -224,6 +224,15 @@ class DisplayObject extends EventDispatcher, implements IBitmapDrawable {
 	
 	public function hitTestObject(obj:DisplayObject):Bool {
 		
+		if (obj != null && obj.parent != null && parent != null) {
+			
+			var currentBounds = getBounds(this);
+			var targetBounds = obj.getBounds(this);
+			
+			return currentBounds.intersects(targetBounds);
+			
+		}
+		
 		return false;
 		
 	}


### PR DESCRIPTION
This adds an implementation of browser.display.DisplayObject.hitTestObject(obj:DisplayObject), which was missing in previous versions.
Works perfectly in my Breakout-style game.

[View issue #NME-226](https://haxenme.atlassian.net/browse/NME-226).
