### PR TITLE
JNI fixes to prevent the global ref table from overflowing

### DIFF
--- a/project/android/JNI.cpp
+++ b/project/android/JNI.cpp
@@ -274,17 +274,16 @@ struct JNIObject : public nme::Object
    {
       mObject = inObject;
       if (mObject)
-         globalClass = reinterpret_cast<jclass>(GetEnv()->NewGlobalRef(mObject));
+         mObject = (GetEnv()->NewGlobalRef(mObject));
    }
    ~JNIObject()
    {
-      if (globalClass)
-         GetEnv()->DeleteGlobalRef(globalClass);
+      if (mObject)
+         GetEnv()->DeleteGlobalRef(mObject);
    }
    operator jobject() { return mObject; }
    jobject GetJObject() { return mObject; }
    jobject mObject;
-   jclass globalClass;
 };
 
 


### PR DESCRIPTION
Based on a JNI tips article I read (http://developer.android.com/training/articles/perf-jni.html... ) it seems that NewGlobalRef and DeleteGlobalRef were being used incorrectly. NewGlobalRef returns a jclass instance and that is what you pass to DeleteGlobalRef.  Without this the DeleteGlobalRef call dumps a warning to the android log and eventually a threshold is hit that will crash the app.
