### PR TITLE
'fix' override field error get_stage on flash application template

### DIFF
--- a/templates/default/flash/haxe/ApplicationMain.hx
+++ b/templates/default/flash/haxe/ApplicationMain.hx
@@ -149,7 +149,7 @@ class DocumentClass {
 				var method = macro {
 					return flash.Lib.current.stage;
 				}
-				fields.push ({ name: "get_stage", access: [ APrivate #if nme, AOverride #end ], meta: [ { name: ":getter", params: [ macro stage ], pos: Context.currentPos() } ], kind: FFun({ args: [], expr: method, params: [], ret: macro :flash.display.Stage }), pos: Context.currentPos() });
+				//fields.push ({ name: "get_stage", access: [ APrivate #if nme, AOverride #end ], meta: [ { name: ":getter", params: [ macro stage ], pos: Context.currentPos() } ], kind: FFun({ args: [], expr: method, params: [], ret: macro :flash.display.Stage }), pos: Context.currentPos() });
 				return fields;
 			}
 			searchTypes = searchTypes.superClass.t.get();


### PR DESCRIPTION
error message: bin/flash/haxe/ApplicationMain.hx:134: characters 0-56 : Field get_stage is declared 'override' but doesn't override any field

I don't really know what the line I commented out is supposed to do, but stage seems to be accessed via field (DisplayObject.stage(default,null)), My DocumentClass does not have a custom stage property. Commenting it out lets me compile and run my application again. I suppose a real fix would be related to access and AOverride, but I have no idea about macros.

PS: are there any automated tests to run before commiting/pull-requesting?
