### PR TITLE
BitmapData.threshold() for CPP target.

### DIFF
--- a/native/display/BitmapData.hx
+++ b/native/display/BitmapData.hx
@@ -316,16 +316,16 @@ class BitmapData implements IBitmapDrawable
         //Int has 32 bits - 4 bytes (except neko 1.8)
 
         //compare first - "head" bytes
-        tmp1 = n1 >> 24; //shift integers by 24 bits right for this purpose, so only head bytes left (0xFF)
-        tmp2 = n2 >> 24;
+        tmp1 = (n1 >> 24) & 0x000000FF; //shift integers by 24 bits right for this purpose, so only head bytes left (0xFF)
+        tmp2 = (n2 >> 24) & 0x000000FF;
         if( tmp1 != tmp2 ){
             //if head bytes are not equal, we can already know, which one is bigger
             return (tmp1 > tmp2 ? 1 : -1);
 
         //compare second byte
         }else{
-            tmp1 = (n1 >> 16) & 0x00FF; //tmp1 now contains 0x3D
-            tmp2 = (n2 >> 16) & 0x00FF; //tmp2 now contains 0x3D
+            tmp1 = (n1 >> 16) & 0x000000FF; //tmp1 now contains 0x3D
+            tmp2 = (n2 >> 16) & 0x000000FF; //tmp2 now contains 0x3D
 
             if( tmp1 != tmp2 ){
                 return (tmp1 > tmp2 ? 1 : -1);
@@ -333,8 +333,8 @@ class BitmapData implements IBitmapDrawable
             //compare third byte
             }else{
 
-                tmp1 = (n1 >> 8) & 0x0000FF; //tmp1 now contains 0x76
-                tmp2 = (n2 >> 8) & 0x0000FF; //tmp2 now contains 0x76
+                tmp1 = (n1 >> 8) & 0x000000FF; //tmp1 now contains 0x76
+                tmp2 = (n2 >> 8) & 0x000000FF; //tmp2 now contains 0x76
 
                 if( tmp1 != tmp2 ){
                     return (tmp1 > tmp2 ? 1 : -1);


### PR DESCRIPTION
BitmapData.threshold() implementation for cpp target. Pretty fast! Also tested and accurate - same visuals and return values as Flash API version. Got lots of help from crazysam (Sam Batista) and the HaxeFlixel community on this one.

This is my first pull request, so let me know if I did it wrong or need to fix something!

More details:
http://www.haxeflixel.com/forum/general-discussion/bitmapdatathreshold-palette-swap-solution-cpp-target
http://www.nme.io/community/forums/feature-requests/my-implementation-bitmapdatathreshold-cpp-target/#ccm-discussion-post-anchor

Three test images are used below: one grid of greyscale values, one grid of bluescale values, and one giant huge benchmark image full of yellow smiley faces (the benchmark color-swaps the yellow shades to cyan).

![nme_threshold_flash](https://f.cloud.github.com/assets/739064/353963/63400df8-a090-11e2-807b-c01db32ab29d.png)
![nme_threshold_cpp](https://f.cloud.github.com/assets/739064/353964/65529494-a090-11e2-8f0e-e8997b246ece.png)
