### PR TITLE
Handle keyboard events for Android target

### DIFF
--- a/templates/default/android/template/src/org/haxe/nme/MainView.java
+++ b/templates/default/android/template/src/org/haxe/nme/MainView.java
@@ -340,7 +340,7 @@ class MainView extends GLSurfaceView {
              queueEvent(new Runnable() {
                  // This method will be called on the rendering thread:
                  public void run() {
-                     //me.HandleResult(NME.onKeyChange(keyCode,true));
+                     me.HandleResult(NME.onKeyChange(keyCode,true));
                      me.HandleResult(NME.onJoyChange(deviceId,keyCode,true));
                  }});
              return true;
@@ -361,7 +361,7 @@ class MainView extends GLSurfaceView {
              queueEvent(new Runnable() {
                  // This method will be called on the rendering thread:
                  public void run() {
-                     //me.HandleResult(NME.onKeyChange(keyCode,false));
+                     me.HandleResult(NME.onKeyChange(keyCode,false));
                      me.HandleResult(NME.onJoyChange(deviceId,keyCode,false));
                  }});
              return true;


### PR DESCRIPTION
Without this changes keyboard events not propagate from java to haxe for android target.

Or maybe I missing something?

My platform: haxe 3 and nme 4.
