### PR TITLE
Add setTextFormat support for indexed regions to browser.text.TextField

### DIFF
--- a/browser/text/TextField.hx
+++ b/browser/text/TextField.hx
@@ -27,10 +27,10 @@ typedef StringMap<T> = Hash<T>;
 
 
 class TextField extends InteractiveObject {
-	
-	
+
+
 	public static var mDefaultFont = Font.DEFAULT_FONT_NAME;
-	
+
 	public var antiAliasType:String;
 	public var autoSize(default, set_autoSize):String;
 	public var background(default,set_background):Bool;
@@ -63,9 +63,9 @@ class TextField extends InteractiveObject {
 	public var textWidth(get_textWidth, null):Float;
 	public var type(get_type, set_type):String;
 	public var wordWrap(default, set_wordWrap):Bool;
-	
+
 	private static var sSelectionOwner:TextField = null;
-	
+
 	private var mAlign:TextFormatAlign;
 	private var mHeight:Float;
 	private var mHTMLText:String;
@@ -89,12 +89,12 @@ class TextField extends InteractiveObject {
 	private var nmeGraphics:Graphics;
 	private var nmeInputEnabled:Bool;
 	private var _defaultTextFormat:TextFormat;
-	
-	
+
+
 	public function new() {
-		
+
 		super();
-		
+
 		mWidth = 100;
 		mHeight = 20;
 		mHTMLMode = false;
@@ -107,7 +107,7 @@ class TextField extends InteractiveObject {
 		mSelEnd = -1;
 		mScrollH = 0;
 		mScrollV = 1;
-		
+
 		mType = TextFieldType.DYNAMIC;
 		autoSize = TextFieldAutoSize.NONE;
 		mTextHeight = 12;
@@ -122,225 +122,225 @@ class TextField extends InteractiveObject {
 		nmeInputEnabled = false;
 		mDownChar = 0;
 		mSelectDrag = -1;
-		
+
 		mLineInfo = [];
 		defaultTextFormat = new TextFormat();
-		
+
 		borderColor = 0x000000;
 		border = false;
 		backgroundColor = 0xffffff;
 		background = false;
 		gridFitType = GridFitType.PIXEL;
 		sharpness = 0;
-		
+
 	}
-	
-	
+
+
 	public function appendText(newText:String):Void {
-		
+
 		this.text += newText;
-		
+
 	}
-	
-	
+
+
 	public function ConvertHTMLToText(inUnSetHTML:Bool):Void {
-		
+
 		mText = "";
-		
+
 		for (paragraph in mParagraphs) {
-			
+
 			for (span in paragraph.spans) {
-				
+
 				mText += span.text;
-				
+
 			}
-			
+
 			// + \n ?
-			
+
 		}
-		
+
 		if (inUnSetHTML) {
-			
+
 			mHTMLMode = false;
 			RebuildText();
-			
+
 		}
-		
+
 	}
-	
-	
+
+
 	private function DecodeColour(col:String):Int {
-		
+
 		return Std.parseInt("0x" + col.substr(1));
-		
+
 	}
-	
-	
+
+
 	public function getCharBoundaries(a:Int):Rectangle {
-		
+
 		// TODO
 		return null;
-		
+
 	}
-	
-	
+
+
 	public function getCharIndexAtPoint(inX:Float, inY:Float):Int {
-		
+
 		var li = getLineIndexAtPoint(inX, inY);
-		
+
 		if (li < 0) {
-			
+
 			return -1;
-			
+
 		}
-		
+
 		var line = mLineInfo[li];
 		var idx = line.mIndex;
-		
+
 		for (x in line.mX) {
-			
+
 			if (x > inX) return idx;
 			idx++;
-			
+
 		}
-		
+
 		return idx;
-		
+
 	}
-	
-	
+
+
 	public function getLineIndexAtPoint(inX:Float, inY:Float):Int {
-		
+
 		if (mLineInfo.length < 1) return -1;
 		if (inY <= 0) return 0;
-		
+
 		for (l in 0...mLineInfo.length) {
-			
+
 			if (mLineInfo[l].mY0 > inY) {
-				
+
 				return l == 0 ? 0 : l - 1;
-				
+
 			}
-			
+
 		}
-		
+
 		return mLineInfo.length - 1;
-		
+
 	}
-	
-	
+
+
 	public function getTextFormat(beginIndex:Int = 0, endIndex:Int = 0):TextFormat {
-		
+
 		return new TextFormat();
-		
+
 	}
-	
-	
+
+
 	private override function nmeGetGraphics():Graphics {
-		
+
 		return nmeGraphics;
-		
+
 	}
-	
-	
+
+
 	override public function nmeGetObjectUnderPoint(point:Point):DisplayObject {
-		
+
 		if (!visible) {
-			
-			return null; 
-			
+
+			return null;
+
 		} else if (this.mText.length > 1) {
-			
+
 			var local = globalToLocal(point);
-			
+
 			if (local.x < 0 || local.y < 0 || local.x > mMaxWidth || local.y > mMaxHeight) {
-				
+
 				return null;
-				
+
 			} else {
-				
+
 				return cast this;
-				
+
 			}
-			
+
 		} else {
-			
+
 			return super.nmeGetObjectUnderPoint(point);
-			
+
 		}
-		
+
 	}
-	
-	
+
+
 	override public function nmeRender(inMask:CanvasElement = null, clipRect:Rectangle = null):Void {
-		
+
 		if (!nmeCombinedVisible) return;
 		if (_matrixInvalid || _matrixChainInvalid) nmeValidateMatrix();
-		
+
 		if (nmeGraphics.nmeRender(inMask, nmeFilters, 1, 1)) {
-			
+
 			handleGraphicsUpdated(nmeGraphics);
-			
+
 		}
-		
+
 		if (!mHTMLMode && inMask != null) {
-			
+
 			var m = getSurfaceTransform(nmeGraphics);
 			Lib.nmeDrawToSurface(nmeGraphics.nmeSurface, inMask, m,(parent != null ? parent.nmeCombinedAlpha : 1) * alpha, clipRect);
-			
+
 		} else {
-			
+
 			if (nmeTestFlag(DisplayObject.TRANSFORM_INVALID)) {
-				
+
 				var m = getSurfaceTransform(nmeGraphics);
 				Lib.nmeSetSurfaceTransform(nmeGraphics.nmeSurface, m);
 				nmeClearFlag(DisplayObject.TRANSFORM_INVALID);
-				
+
 			}
-			
+
 			Lib.nmeSetSurfaceOpacity(nmeGraphics.nmeSurface,(parent != null ? parent.nmeCombinedAlpha : 1) * alpha);
-			
+
 			/*if (clipRect != null) {
 				var rect = new Rectangle();
 				rect.topLeft = this.globalToLocal(this.parent.localToGlobal(clipRect.topLeft));
 				rect.bottomRight = this.globalToLocal(this.parent.localToGlobal(clipRect.bottomRight));
 				Lib.nmeSetSurfaceClipping(nmeGraphics.nmeSurface, rect);
 			}*/
-			
+
 		}
-		
+
 	}
-	
-	
+
+
 	private function Rebuild() {
-		
+
 		if (mHTMLMode) return;
-		
+
 		mLineInfo = [];
 		nmeGraphics.clear();
-		
+
 		if (background) {
-			
+
 			nmeGraphics.beginFill(backgroundColor);
 			nmeGraphics.drawRect( 0, 0, width, height );
 			nmeGraphics.endFill();
-			
+
 		}
 
 		nmeGraphics.lineStyle(mTextColour);
 		var insert_x:Null<Int> = null;
 		mMaxWidth = 0;
-		
+
 		//mLimitRenderX = (autoSize == browser.text.TextFieldAutoSize.NONE) ? Std.int(width) : 999999;
 		var wrap = mLimitRenderX = (wordWrap && !nmeInputEnabled) ? Std.int(mWidth) : 999999;
 		var char_idx = 0;
 		var h:Int = 0;
-		
+
 		var s0 = mSelStart;
 		var s1 = mSelEnd;
-		
+
 		for (paragraph in mParagraphs) {
-			
+
 			var row:Array<RowChar> = [];
 			var row_width = 0;
 			var last_word_break = 0;
@@ -348,439 +348,492 @@ class TextField extends InteractiveObject {
 			var last_word_char_idx = 0;
 			var start_idx = char_idx;
 			var tx = 0;
-			
+
 			for (span in paragraph.spans) {
-				
+
 				var text = span.text;
 				var font = span.font;
 				var fh = font.height;
-				
+
 				last_word_break = row.length;
 				last_word_break_width = row_width;
 				last_word_char_idx = char_idx;
-				
+
 				for (ch in 0...text.length) {
-					
+
 					var g = text.charCodeAt(ch);
 					var adv = font.nmeGetAdvance(g);
-					
+
 					if (g == 32) {
-						
+
 						last_word_break = row.length;
 						last_word_break_width = tx;
 						last_word_char_idx = char_idx;
-						
+
 					}
-					
+
 					if ((tx + adv) > wrap ) {
-						
+
 						if (last_word_break > 0) {
-							
+
 							var row_end = row.splice(last_word_break, row.length - last_word_break);
 							h += RenderRow(row, h, start_idx, paragraph.align);
 							row = row_end;
 							tx -= last_word_break_width;
 							start_idx = last_word_char_idx;
-							
+
 							last_word_break = 0;
 							last_word_break_width = 0;
 							last_word_char_idx = 0;
-							
+
 							if (row_end.length > 0 && row_end[0].chr == 32) {
-								
+
 								row_end.shift();
 								start_idx ++;
-								
+
 							}
-							
+
 						} else {
-							
+
 							h += RenderRow(row, h, char_idx, paragraph.align);
 							row = [];
 							tx = 0;
 							start_idx = char_idx;
-							
+
 						}
-						
+
 					}
-					
+
 					row.push( { font: font, chr: g, x: tx, fh: fh, sel:(char_idx >= s0 && char_idx < s1), adv: adv } );
 					tx += adv;
 					char_idx++;
-					
+
 				}
-				
+
 			}
-			
+
 			if (row.length > 0) {
-				
+
 				h += RenderRow(row, h, start_idx, paragraph.align, insert_x);
 				insert_x = null;
-				
+
 			}
-			
+
 		}
-		
+
 		var w = mMaxWidth;
-		
+
 		if (h < mTextHeight) {
-			
+
 			h = mTextHeight;
-			
+
 		}
-		
+
 		mMaxHeight = h;
-		
+
 		switch (autoSize) {
-			
+
 			case TextFieldAutoSize.LEFT:
 			case TextFieldAutoSize.RIGHT:
-				
+
 				var x0 = x + width;
 				x = mWidth - x0;
-			
+
 			case TextFieldAutoSize.CENTER:
-				
+
 				var x0 = x + width/2;
 				x = mWidth / 2 - x0;
-			
+
 			default:
-				
+
 				if (wordWrap)
 					height = h;
-			
+
 		}
-		
+
 		if (border) {
-			
+
 			nmeGraphics.endFill();
 			nmeGraphics.lineStyle(1, borderColor, 1, true);
 			nmeGraphics.drawRect(.5, .5, width-.5, height-.5);
-			
+
 		}
-		
+
 	}
-	
-	
+
+
 	public function RebuildText() {
-		
+
 		mParagraphs = [];
-		
+
 		if (!mHTMLMode) {
-			
+
 			var font = FontInstance.CreateSolid(mFace, mTextHeight, mTextColour, 1.0);
 			var paras = mText.split("\n");
-			
+
 			for (paragraph in paras) {
-				
+
 				mParagraphs.push( { align: mAlign, spans: [ { font : font, text: paragraph + "\n" } ] } );
-				
+
 			}
-			
+
 		}
-		
+
 		Rebuild();
-		
+
 	}
-	
-	
+
+
 	private function RenderRow(inRow:Array<RowChar>, inY:Int, inCharIdx:Int, inAlign:TextFormatAlign, inInsert:Int = 0):Int {
-		
+
 		var h = 0;
 		var w = 0;
-		
+
 		for (chr in inRow) {
-			
+
 			if (chr.fh > h) {
-				
+
 				h = chr.fh;
-				
+
 			}
-			
+
 			w += chr.adv;
-			
+
 		}
-		
+
 		if (w > mMaxWidth) {
-			
+
 			mMaxWidth = w;
-			
+
 		}
-		
+
 		var full_height = Std.int(h * 1.2);
 		var align_x = 0;
 		var insert_x = 0;
-		
+
 		if (inInsert != null) {
-			
+
 			// TODO: check if this is necessary.
 			if (autoSize != TextFieldAutoSize.NONE) {
-				
+
 				mScrollH = 0;
 				insert_x = inInsert;
-				
+
 			} else {
-				
+
 				insert_x = inInsert - mScrollH;
-				
+
 				if (insert_x < 0) {
-					
+
 					mScrollH -= ((mLimitRenderX * 3) >> 2 ) - insert_x;
-					
+
 				} else if (insert_x > mLimitRenderX) {
-					
+
 					mScrollH +=  insert_x - ((mLimitRenderX * 3) >> 2);
-					
+
 				}
-				
+
 				if (mScrollH < 0) {
-					
+
 					mScrollH = 0;
-					
+
 				}
-				
+
 			}
-			
+
 		}
-		
+
 		if (autoSize == TextFieldAutoSize.NONE && w <= mLimitRenderX) {
 			if (inAlign == TextFormatAlign.CENTER) {
 
 				align_x = (Math.round(mWidth)-w)>>1;
 
 			} else if (inAlign == TextFormatAlign.RIGHT) {
-				
+
 				align_x = Math.round(mWidth)-w;
-				
+
 			}
 		}
-		
+
 		var x_list = new Array<Int>();
 		mLineInfo.push( { mY0: inY, mIndex: inCharIdx - 1, mX: x_list } );
-		
+
 		var cache_sel_font:FontInstance = null;
 		var cache_normal_font:FontInstance = null;
 		var x = align_x - mScrollH;
 		var x0 = x;
-		
+
 		for (chr in inRow) {
-			
+
 			var adv = chr.adv;
-			
+
 			if (x + adv > mLimitRenderX) {
-				
+
 				break;
-				
+
 			}
-			
+
 			x_list.push(x);
-			
+
 			if (x >= 0) {
-				
+
 				var font = chr.font;
-				
+
 				if (chr.sel) {
-					
+
 					nmeGraphics.lineStyle();
 					nmeGraphics.beginFill(0x202060);
 					nmeGraphics.drawRect(x, inY, adv, full_height);
 					nmeGraphics.endFill();
-					
+
 					if (cache_normal_font == chr.font) {
-						
+
 						font = cache_sel_font;
-						
+
 					} else {
-						
+
 						font = FontInstance.CreateSolid(chr.font.GetFace(), chr.fh, 0xffffff, 1.0);
 						cache_sel_font = font;
 						cache_normal_font = chr.font;
-						
+
 					}
-					
+
 				}
-				
+
 				font.RenderChar(nmeGraphics, chr.chr, x, Std.int(inY + (h - chr.fh)));
-				
+
 			}
-			
+
 			x += adv;
-			
+
 		}
-		
+
 		x += mScrollH;
 		return full_height;
-		
+
 	}
-	
-	
+
+
 	public function setSelection(beginIndex:Int, endIndex:Int) {
-		
+
 		// TODO:
-		
+
 	}
-	
-	
-	public function setTextFormat(inFmt:TextFormat, beginIndex:Int = 0, endIndex:Int = 0) {
-		
-		if (inFmt.font != null) {
+
+	private function BuildModifiedFont(inFmt:TextFormat) : FontInstance {
+		var newFace = mFace;
+		var newTextHeight = mTextHeight;
+		var newTextColour = mTextColour;
+
+		if (inFmt.font != null)  newFace = inFmt.font;
+		if (inFmt.size != null)  newTextHeight = Std.int(inFmt.size);
+		if (inFmt.color != null) newTextColour = inFmt.color;
+
+		return FontInstance.CreateSolid(newFace, newTextHeight, newTextColour, 1.0);
+	}
+
+
+	public function setTextFormat(inFmt:TextFormat, beginIndex:Int = -1, endIndex:Int = -1) {
+
+		if((beginIndex < 0 && endIndex < 0) || mHTMLMode)
+		{
+			if (inFmt.font != null) {
+				mFace = inFmt.font;
+			}
+
+			if (inFmt.size != null) {
+				mTextHeight = Std.int(inFmt.size);
+			}
+
+			if (inFmt.align != null) {
+				mAlign = inFmt.align;
+			}
+
+			if (inFmt.color != null) {
+				mTextColour = inFmt.color;
+			}
+
+			this.RebuildText();
+			nmeInvalidateBounds();
 			
-			mFace = inFmt.font;
+			return getTextFormat();
+
+		} else {
+			if(endIndex < 0) {
+				endIndex = mText.length;
+			} else if(beginIndex < 0) {
+				beginIndex = 0;
+			}
 			
+			// Not HTML, and indexes are set, and affecting some region
+			var spanStart = 0;
+
+			for (paragraph in mParagraphs) {
+				var newSpans = new Array<Span>();
+
+				for (span in paragraph.spans) {
+					var relativeBegin = beginIndex - spanStart;
+					var relativeEnd = endIndex - spanStart;
+
+					// if not covering this span
+					if(relativeBegin > span.text.length || relativeEnd < 0) {
+						newSpans.push(span);
+					} else {
+						// split it into the part before, in, and after
+						if(relativeBegin > 0) {
+							newSpans.push( { font: span.font, text: span.text.substring(0, relativeBegin) } );
+						}
+
+						newSpans.push( {
+							font: BuildModifiedFont(inFmt),
+							text: span.text.substring(relativeBegin < 0 ? 0 : relativeBegin, relativeEnd) } );
+
+						if(relativeEnd < span.text.length) {
+							newSpans.push( { font: span.font, text: span.text.substring(relativeEnd) } );
+						}
+					}
+
+					spanStart += span.text.length;
+				}
+
+				paragraph.spans = newSpans;
+			}
 		}
-		
-		if (inFmt.size != null) {
-			
-			mTextHeight = Std.int(inFmt.size);
-			
-		}
-		
-		if (inFmt.align != null) {
-			
-			mAlign = inFmt.align;
-			
-		}
-		
-		if (inFmt.color != null) {
-			
-			mTextColour = inFmt.color;
-			
-		}
-		
-		RebuildText();
+
+		this.Rebuild();
 		nmeInvalidateBounds();
-		
-		return getTextFormat();
-		
+
+		return inFmt;
+
 	}
-	
-	
+
+
 	override public function toString():String {
-		
+
 		return "[TextField name=" + this.name + " id=" + _nmeId + "]";
-		
+
 	}
-	
-	
-	
-	
+
+
+
+
 	// Getters & Setters
-	
-	
-	
-	
+
+
+
+
 	private function set_autoSize(inAutoSize:String):String {
-		
+
 		autoSize = inAutoSize;
 		Rebuild();
 		return inAutoSize;
-		
+
 	}
-	
-	
+
+
 	private function set_background(inBack:Bool):Bool {
 		background = inBack;
 		Rebuild();
 		return inBack;
-		
+
 	}
-	
-	
+
+
 	private function set_backgroundColor(inCol:Int):Int {
-		
+
 		backgroundColor = inCol;
 		Rebuild();
 		return inCol;
-		
+
 	}
-	
-	
+
+
 	private function set_border(inBorder:Bool):Bool {
-		
+
 		border = inBorder;
 		Rebuild();
 		return inBorder;
-		
+
 	}
-	
-	
+
+
 	private function set_borderColor(inBorderCol:Int):Int {
-		
+
 		borderColor = inBorderCol;
 		Rebuild();
 		return inBorderCol;
-		
+
 	}
-	
-	
+
+
 	private function get_caretPos():Int {
-		
+
 		return mInsertPos;
-		
+
 	}
-	
-	
+
+
 	private function get_defaultTextFormat():TextFormat {
-		
+
 		return _defaultTextFormat;
-		
+
 	}
-	
-	
+
+
 	private function set_defaultTextFormat(inFmt:TextFormat):TextFormat {
-		
+
 		setTextFormat(inFmt);
 		_defaultTextFormat = inFmt;
 		return inFmt;
-		
+
 	}
-	
-	
+
+
 	private override function get_height():Float {
-		
+
 		return Math.max(mHeight,getBounds(this.stage).height);
-		
+
 	}
-	
-	
+
+
 	override private function set_height(inValue:Float):Float {
-		
+
 		if (parent != null) {
-			
+
 			parent.nmeInvalidateBounds();
-			
+
 		}
-		
+
 		if (_boundsInvalid) {
-			
+
 			validateBounds();
-			
+
 		}
-		
+
 		if (inValue != mHeight) {
-			
+
 			mHeight = inValue;
 			Rebuild();
-			
+
 		}
-		
+
 		return mHeight;
-		
+
 	}
-	
-	
+
+
 	public function get_htmlText():String {
-		
+
 		return mHTMLText;
-		
+
 	}
-	
-	
+
+
 	public function set_htmlText(inHTMLText:String):String {
-		
+
 		mParagraphs = new Paragraphs();
 		mHTMLText = inHTMLText;
-		
+
 		if (!mHTMLMode) {
 			var domElement:Dynamic = Browser.document.createElement("div");
 
@@ -806,154 +859,154 @@ class TextField extends InteractiveObject {
 
 			var wrapper:CanvasElement = cast domElement;
 			wrapper.innerHTML = inHTMLText;
-			
+
 			var destination = new Graphics(wrapper);
 			var nmeSurface = nmeGraphics.nmeSurface;
-			
+
 			if (Lib.nmeIsOnStage(nmeSurface)) {
-				
+
 				Lib.nmeAppendSurface(wrapper);
 				Lib.nmeCopyStyle(nmeSurface, wrapper);
 				Lib.nmeSwapSurface(nmeSurface, wrapper);
 				Lib.nmeRemoveSurface(nmeSurface);
-				
+
 			}
-			
+
 			nmeGraphics = destination;
 			nmeGraphics.nmeExtent.width = wrapper.width;
 			nmeGraphics.nmeExtent.height = wrapper.height;
-			
+
 		} else {
 			nmeGraphics.nmeSurface.innerHTML = inHTMLText;
-			
+
 		}
 
 		mHTMLMode = true;
 		RebuildText();
 		nmeInvalidateBounds();
-		
+
 		return mHTMLText;
-		
+
 	}
-	
-	
+
+
 	public function get_text():String {
-		
+
 		if (mHTMLMode) {
-			
+
 			ConvertHTMLToText(false);
-			
+
 		}
-		
+
 		return mText;
-		
+
 	}
-	
-	
+
+
 	public function set_text(inText:String):String {
-		
+
 		mText = Std.string(inText);
 		//mHTMLText = inText;
 		mHTMLMode = false;
 		RebuildText();
 		nmeInvalidateBounds();
-		
+
 		return mText;
-		
+
 	}
-	
-	
+
+
 	public function get_textColor():Int { return mTextColour; }
 	public function set_textColor(inCol:Int):Int {
-		
+
 		mTextColour = inCol;
 		RebuildText();
 		return inCol;
-		
+
 	}
-	
-	
+
+
 	public function get_textWidth():Float { return mMaxWidth; }
 	public function get_textHeight():Float { return mMaxHeight; }
-	
-	
+
+
 	public function get_type():String { return mType; }
 	public function set_type(inType:String):String {
-		
+
 		mType = inType;
 		nmeInputEnabled = (mType == TextFieldType.INPUT);
-		
+
 		if (mHTMLMode) {
-			
+
 			if (nmeInputEnabled) {
-				
+
 				Lib.nmeSetContentEditable(nmeGraphics.nmeSurface, true);
-				
+
 			} else {
-				
+
 				Lib.nmeSetContentEditable(nmeGraphics.nmeSurface, false);
-				
+
 			}
-			
+
 		} else if (nmeInputEnabled) {
-			
+
 			// implicitly convert text to a HTML field, and set contenteditable
 			set_htmlText(StringTools.replace(mText, "\n", "<BR />"));
 			Lib.nmeSetContentEditable(nmeGraphics.nmeSurface, true);
-			
+
 		}
-		
+
 		tabEnabled = (type == TextFieldType.INPUT);
-		
+
 		Rebuild();
-		
+
 		return inType;
-		
+
 	}
-	
-	
+
+
 	override public function get_width():Float {
-		
+
 		return Math.max(mWidth,getBounds(this.stage).width);
-		
+
 	}
-	
-	
+
+
 	override public function set_width(inValue:Float):Float {
-		
+
 		if (parent != null) {
-			
+
 			parent.nmeInvalidateBounds();
-			
+
 		}
-		
+
 		if (_boundsInvalid) {
-			
+
 			validateBounds();
-			
+
 		}
-		
+
 		if (inValue != mWidth) {
-			
+
 			mWidth = inValue;
 			Rebuild();
-			
+
 		}
-		
+
 		return mWidth;
-		
+
 	}
-	
-	
+
+
 	public function set_wordWrap(inWordWrap:Bool):Bool {
-		
+
 		wordWrap = inWordWrap;
 		Rebuild();
 		return wordWrap;
-		
+
 	}
-	
-	
+
+
 }
 
 
@@ -965,20 +1018,20 @@ import browser.display.BitmapData;
 
 
 enum FontInstanceMode {
-	
+
 	fimSolid;
-	
+
 }
 
 
 class FontInstance {
-	
-	
+
+
 	public var height(get_height, null):Int;
 	public var mTryFreeType:Bool;
-	
+
 	private static var mSolidFonts = new StringMap<FontInstance>();
-	
+
 	private var mMode:FontInstanceMode;
 	private var mColour:Int;
 	private var mAlpha:Float;
@@ -986,130 +1039,130 @@ class FontInstance {
 	private var mHeight:Int;
 	private var mGlyphs:Array<Element>;
 	private var mCacheAsBitmap:Bool;
-	
-	
+
+
 	private function new(inFont:Font, inHeight:Int) {
-		
+
 		mFont = inFont;
 		mHeight = inHeight;
 		mTryFreeType = true;
 		mGlyphs = [];
 		mCacheAsBitmap = false;
-		
+
 	}
-	
-	
+
+
 	static public function CreateSolid(inFace:String, inHeight:Int, inColour:Int, inAlpha:Float):FontInstance {
-		
+
 		var id = "SOLID:" + inFace+ ":" + inHeight + ":" + inColour + ":" + inAlpha;
 		var f:FontInstance =  mSolidFonts.get(id);
-		
+
 		if (f != null) {
-			
+
 			return f;
-			
+
 		}
-		
+
 		var font:Font = new Font();
 		font.nmeSetScale(inHeight);
 		font.fontName = inFace;
-		
+
 		if (font == null) {
-			
+
 			return null;
-			
+
 		}
-		
+
 		f = new FontInstance(font, inHeight);
 		f.SetSolid(inColour, inAlpha);
 		mSolidFonts.set(id, f);
-		
+
 		return f;
-		
+
 	}
-	
-	
+
+
 	public function GetFace():String {
-		
+
 		return mFont.fontName;
-		
+
 	}
-	
-	
+
+
 	public function nmeGetAdvance(inChar:Int):Int {
-		
+
 		if (mFont == null) return 0;
 		return mFont.nmeGetAdvance(inChar, mHeight);
-		
+
 	}
-	
-	
+
+
 	private function SetSolid(inCol:Int, inAlpha:Float):Void {
-		
+
 		mColour = inCol;
 		mAlpha = inAlpha;
 		mMode = fimSolid;
-		
+
 	}
-	
-	
+
+
 	public function RenderChar(inGraphics:Graphics, inGlyph:Int, inX:Int, inY:Int):Void {
-		
+
 		inGraphics.nmeClearLine();
 		inGraphics.beginFill(mColour, mAlpha);
 		mFont.nmeRender(inGraphics, inGlyph, inX, inY, mTryFreeType);
 		inGraphics.endFill();
-		
+
 	}
-	
-	
+
+
 	public function toString():String {
-		
+
 		return "FontInstance:" + mFont + ":" + mColour + "(" + mGlyphs.length + ")";
-		
+
 	}
-	
-	
-	
-	
+
+
+
+
 	// Getters & Setters
-	
-	
-	
-	
+
+
+
+
 	private function get_height():Int {
-		
+
 		return mHeight;
-		
+
 	}
-	
-	
+
+
 }
 
 
 typedef SpanAttribs = {
-	
+
 	var face:String;
 	var height:Int;
 	var colour:Int;
 	var align:TextFormatAlign;
-	
+
 }
 
 
 typedef Span = {
-	
+
 	var font:FontInstance;
 	var text:String;
-	
+
 }
 
 
 typedef Paragraph = {
-	
+
 	var align:TextFormatAlign;
 	var spans: Array<Span>;
-	
+
 }
 
 
@@ -1117,23 +1170,23 @@ typedef Paragraphs = Array<Paragraph>;
 
 
 typedef LineInfo = {
-	
+
 	var mY0:Int;
 	var mIndex:Int;
 	var mX:Array<Int>;
-	
+
 }
 
 
 typedef RowChar = {
-	
+
 	var x:Int;
 	var fh:Int;
 	var adv:Int;
 	var chr:Int;
 	var font:FontInstance;
 	var sel:Bool;
-	
+
 }
 
 

--- a/samples/02-Text/Sample.hx
+++ b/samples/02-Text/Sample.hx
@@ -1,4 +1,4 @@
-import flash.Lib;
+import nme.Lib;
 
 class Sample
 {
@@ -7,36 +7,56 @@ public static function main()
 {
    var gfx = Lib.current.graphics;
    gfx.beginFill(0x000000);
-   gfx.drawRect(120,0,120,120);
+   gfx.drawRect(120,0,120,320);
 
    for(side in 0...2)
    {
-      var col = side * 0xffffff;
-      var text = new flash.text.TextField();
+      var col = (0xFF + side * 0xFF ) % 0xffffff;
+
+      // Plain text field
+      var text = new nme.text.TextField();
       text.x = 10 + side*120;
       text.y = 10;
       text.textColor = col;
-      text.text = "Hello !";
-      Lib.current.addChild(text);
-      text.stage.scaleMode = flash.display.StageScaleMode.NO_SCALE;
+      text.width = 100;
+      text.wordWrap = true;
 
-      var text = new flash.text.TextField();
+      text.text = "Hello !\nFrom this multi-line, wordwrapped, centred text box!";
+      
+      var fmt = new nme.text.TextFormat();
+      fmt.align = nme.text.TextFormatAlign.CENTER;
+      text.setTextFormat(fmt);
+
+      fmt = new nme.text.TextFormat();
+      fmt.color = 0x660000;
+      text.setTextFormat(fmt, 6, 12);
+
+      fmt.color = 0xFF00FF;
+      text.setTextFormat(fmt, 18);
+
+      Lib.current.addChild(text);
+      text.stage.scaleMode = nme.display.StageScaleMode.NO_SCALE;
+
+      // HTML text fields
+      var text = new nme.text.TextField();
       text.x = 10 + side*120;
-      text.y = 30;
+      text.y = 120;
       text.textColor = col;
       text.htmlText = "<font size='16'>Hello !</font>";
       Lib.current.addChild(text);
  
-      var text = new flash.text.TextField();
+
+      var text = new nme.text.TextField();
       text.x = 10 + side*120;
-      text.y = 50;
+      text.y = 170;
       text.textColor = col;
       text.htmlText = "<font size='24'>Hello !</font>";
       Lib.current.addChild(text);
 
-      var text = new flash.text.TextField();
+
+      var text = new nme.text.TextField();
       text.x = 10 + side*120;
-      text.y = 80;
+      text.y = 220;
       text.textColor = col;
       text.htmlText = "<font size='36'>Hello !</font>";
       Lib.current.addChild(text);


### PR DESCRIPTION
This change implements setting the text format of substrings in the
browser target.

Also trigger RebuildText on a full setTextFormat to handle changing
alignment on existing text, matching the Flash target behaviour.

Update samples/02-Text to include examples of setting text regions.
#### Implementation

Setting a region format splits the existing paragraph spans, and then
sets the format on those spans individually. Doing this repeatedly can
lead to a lot of span fragmentation, which may be a performance issue.
Setting the format for the whole TextField again rebuilds the spans from
scratch again.
#### Limitations:

Currently only supports face, size & colour. Does not gracefully handle
overlapping regions. As there's no simple way to retrieve the TextFormat
from a paragraph span, setting the format of a region inherits default
traits from the internal mFace, mTextHeight & mTextColour variables.
