### PR TITLE
Add setTextFormat support for indexed regions to browser.text.TextField

### DIFF
--- a/samples/02-Text/Sample.hx
+++ b/samples/02-Text/Sample.hx
@@ -1,4 +1,4 @@
-import flash.Lib;
+import nme.Lib;
 
 class Sample
 {
@@ -7,36 +7,56 @@ public static function main()
 {
    var gfx = Lib.current.graphics;
    gfx.beginFill(0x000000);
-   gfx.drawRect(120,0,120,120);
+   gfx.drawRect(120,0,120,320);
 
    for(side in 0...2)
    {
-      var col = side * 0xffffff;
-      var text = new flash.text.TextField();
+      var col = (0xFF + side * 0xFF ) % 0xffffff;
+
+      // Plain text field
+      var text = new nme.text.TextField();
       text.x = 10 + side*120;
       text.y = 10;
       text.textColor = col;
-      text.text = "Hello !";
-      Lib.current.addChild(text);
-      text.stage.scaleMode = flash.display.StageScaleMode.NO_SCALE;
+      text.width = 100;
+      text.wordWrap = true;
 
-      var text = new flash.text.TextField();
+      text.text = "Hello !\nFrom this multi-line, wordwrapped, centred text box!";
+      
+      var fmt = new nme.text.TextFormat();
+      fmt.align = nme.text.TextFormatAlign.CENTER;
+      text.setTextFormat(fmt);
+
+      fmt = new nme.text.TextFormat();
+      fmt.color = 0x660000;
+      text.setTextFormat(fmt, 6, 12);
+
+      fmt.color = 0xFF00FF;
+      text.setTextFormat(fmt, 18);
+
+      Lib.current.addChild(text);
+      text.stage.scaleMode = nme.display.StageScaleMode.NO_SCALE;
+
+      // HTML text fields
+      var text = new nme.text.TextField();
       text.x = 10 + side*120;
-      text.y = 30;
+      text.y = 120;
       text.textColor = col;
       text.htmlText = "<font size='16'>Hello !</font>";
       Lib.current.addChild(text);
  
-      var text = new flash.text.TextField();
+
+      var text = new nme.text.TextField();
       text.x = 10 + side*120;
-      text.y = 50;
+      text.y = 170;
       text.textColor = col;
       text.htmlText = "<font size='24'>Hello !</font>";
       Lib.current.addChild(text);
 
-      var text = new flash.text.TextField();
+
+      var text = new nme.text.TextField();
       text.x = 10 + side*120;
-      text.y = 80;
+      text.y = 220;
       text.textColor = col;
       text.htmlText = "<font size='36'>Hello !</font>";
       Lib.current.addChild(text);


### PR DESCRIPTION
This change implements setting the text format of substrings in the
browser target.
#### Implementation

Setting a region format splits the existing paragraph spans, and then
sets the format on those spans individually. Doing this repeatedly can
lead to a lot of span fragmentation, which may be a performance issue.
Setting the format for the whole TextField again rebuilds the spans from
scratch again.
#### Limitations:

Currently only supports face, size & colour. Does not gracefully handle
overlapping regions. As there's no simple way to retrieve the TextFormat
from a paragraph span, setting the format of a region inherits default
traits from the internal mFace, mTextHeight & mTextColour variables.

Also trigger RebuildText on a full setTextFormat to handle changing
alignment on existing text, matching the Flash target behaviour.

Update samples/02-Text to include examples of setting text regions.
