### PR TITLE
Modified native EventDispatcher to conform to docs regarding event priority

### DIFF
--- a/native/events/EventDispatcher.hx
+++ b/native/events/EventDispatcher.hx
@@ -29,8 +29,31 @@ class EventDispatcher implements IEventDispatcher
 
       var l = new Listener(listener, useCapture, priority);
       list.push(new WeakRef<Listener>(l, useWeakReference));
+     
+      // if pri is 0, it's fine on the end of the list. If not, might be out of order
+      if ( priority != 0 ) {
+         list.sort( sortEvents );
+      }
    }
 
+   private static inline function sortEvents( a:WeakRef<Listener>, b:WeakRef<Listener> ):Int 
+   { 
+      // in theory these can be null, might be best to tread carefully
+      if ( null == a && null == b ) { return 0; }
+      if ( null == a ) { return -1; }
+      if ( null == b ) { return 1; }
+      var al = a.get();
+      var bl = b.get();
+      if ( null == al || null == bl ) { return 0; }
+      if ( al.mPriority == bl.mPriority ) { 
+         // if priorities are the same, ensure original order of addition is maintained
+         return al.mID == bl.mID ? 0 : ( al.mID > bl.mID ? 1 : -1 ); 
+      } else {
+         // otherwise ensure higher priority listeners come first
+         return al.mPriority < bl.mPriority ? 1 : -1;
+      }
+   } 
+   
    public function DispatchCompleteEvent() 
    {
       var evt = new Event(Event.COMPLETE);


### PR DESCRIPTION
Hi, 
Hope this is useful - I haven't managed to figure out how to get your unit tests set up yet (new-ish to haxe etc) but this does appear to work as intended! 

---

Expected behaviour is that higher priority listeners will be called first, and where two listeners have the same priority notification order will be the same as order of addition.

This change ensures the list is always sorted with the highest priority listeners first. It does the sorting on addition rather than dispatch, and it only re-sorts when a listener with a non-zero priority is added (a new zero-priority listener should be at the end of the list in any case).

There's a lot of null-checking in the sort function, perhaps there's no need for it.
