### PR TITLE
Adding onGenericMotionEvent for Android 3.1 and up

### DIFF
--- a/project/android/AndroidFrame.cpp
+++ b/project/android/AndroidFrame.cpp
@@ -37,7 +37,7 @@ int GetResult()
 
 class AndroidStage : public Stage
 {
-    
+
 public:
    AndroidStage(int inWidth,int inHeight,int inFlags) : Stage(true)
    {
@@ -56,7 +56,7 @@ public:
       mDownY = 0;
 
       normalOrientation = 0;
-       
+
    }
    ~AndroidStage()
    {
@@ -87,7 +87,7 @@ public:
          HandleEvent(evt);
       }
    }
- 
+
 
    void OnRender()
    {
@@ -119,7 +119,16 @@ public:
       joystick.code = inCode;
       HandleEvent(joystick);
    }
-   
+
+   void OnJoyMotion(int inDeviceId, int inAxis, float inValue)
+   {
+      Event joystick(etJoyAxisMove);
+      joystick.id = inDeviceId;
+      joystick.code = inAxis;
+      joystick.value = inValue;
+      HandleEvent(joystick);
+   }
+
 
    void OnTrackball(double inX, double inY)
    {
@@ -164,7 +173,7 @@ public:
                   mouse.flags |= efLeftDown;
                }
                mouse.value = inID;
-               
+
                mouse.sx = sizeX;
                mouse.sy = sizeY;
 
@@ -197,7 +206,7 @@ public:
       mOrientationZ = inZ;
       //__android_log_print(ANDROID_LOG_INFO, "NME", "Orientation %f %f %f", inX, inY, inZ);
    }
-   
+
    void OnAccelerate(double inX, double inY, double inZ)
    {
       if (normalOrientation == 0 || normalOrientation == 1) { // UNKNOWN || PORTRAIT
@@ -230,20 +239,20 @@ public:
 
    bool mMultiTouch;
    int  mSingleTouchID;
-  
+
    double mDX;
    double mDY;
-   
+
    int currentDeviceOrientation;
    int normalOrientation;
    double mOrientationX;
    double mOrientationY;
    double mOrientationZ;
-      
+
    double mAccX;
    double mAccY;
    double mAccZ;
-      
+
    double mDownX;
    double mDownY;
 
@@ -273,7 +282,7 @@ public:
 
    virtual void SetTitle() { }
    virtual void SetIcon() { }
-   virtual Stage *GetStage() 
+   virtual Stage *GetStage()
    {
       return sStage;
    }
@@ -512,6 +521,16 @@ JAVA_EXPORT int JNICALL Java_org_haxe_nme_NME_onJoyChange(JNIEnv * env, jobject 
    gc_set_top_of_stack(&top,true);
    if (nme::sStage)
       nme::sStage->OnJoy(deviceId,code,down);
+   gc_set_top_of_stack(0,true);
+   return nme::GetResult();
+}
+
+JAVA_EXPORT int JNICALL Java_org_haxe_nme_NME_onJoyMotion(JNIEnv * env, jobject obj, int deviceId, int axis, int value)
+{
+   int top = 0;
+   gc_set_top_of_stack(&top,true);
+   if (nme::sStage)
+      nme::sStage->OnJoyMotion(deviceId,axis,value);
    gc_set_top_of_stack(0,true);
    return nme::GetResult();
 }

--- a/templates/android/template/AndroidManifest.xml
+++ b/templates/android/template/AndroidManifest.xml
@@ -2,26 +2,26 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:installLocation="::ANDROID_INSTALL_LOCATION::" android:versionCode="::APP_BUILD_NUMBER::" android:versionName="::APP_VERSION::" package="::APP_PACKAGE::">
 
 	<application android:label="::APP_TITLE::" android:debuggable="true"::if (HAS_ICON):: android:icon="@drawable/icon"::end::>
-		
+
 		::if WIN_REQUIRE_SHADERS::<uses-feature android:glEsVersion="0x00020000" android:required="true" />::elseif WIN_ALLOW_SHADERS::<uses-feature android:glEsVersion="0x00020000" android:required="false" />::end::
-		
+
 		<activity android:name="MainActivity" android:label="::APP_TITLE::" android:configChanges="keyboard|keyboardHidden|orientation"::if (WIN_ORIENTATION!=""):: android:screenOrientation="::WIN_ORIENTATION::"::end::>
-			
+
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN" />
 				<category android:name="android.intent.category.LAUNCHER" />
 				<category android:name="ouya.intent.category.GAME"/>
 			</intent-filter>
-			
+
 		</activity>
-		
+
 	</application>
 
-	<uses-sdk android:minSdkVersion="8"/>
-	
+	<uses-sdk android:minSdkVersion="8" android:targetSdkVersion="16"/>
+
 	<uses-permission android:name="android.permission.WAKE_LOCK" />
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.VIBRATE" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-	
-</manifest> 
+
+</manifest>

--- a/templates/android/template/src/org/haxe/nme/HoneycombView.java
+++ b/templates/android/template/src/org/haxe/nme/HoneycombView.java
@@ -1,0 +1,55 @@
+package org.haxe.nme;
+
+import android.app.Activity;
+import android.content.Context;
+import android.view.InputDevice;
+import android.view.MotionEvent;
+
+class HoneycombView extends MainView {
+
+    public HoneycombView(Context context,Activity inActivity) {
+        super(context, inActivity);
+    }
+
+    @Override
+    public boolean onGenericMotionEvent(MotionEvent event) {
+        if ((event.getSource() & InputDevice.SOURCE_CLASS_JOYSTICK) != 0
+            && event.getAction() == MotionEvent.ACTION_MOVE)
+        {
+            final MainView me = this;
+            final int deviceId = event.getDeviceId();
+            final InputDevice device = event.getDevice();
+            // only check axis values of interest
+            int[] axisList = {
+                MotionEvent.AXIS_X, MotionEvent.AXIS_Y, MotionEvent.AXIS_Z,
+                MotionEvent.AXIS_RX, MotionEvent.AXIS_RY, MotionEvent.AXIS_RZ,
+                MotionEvent.AXIS_HAT_X, MotionEvent.AXIS_HAT_Y,
+                MotionEvent.AXIS_LTRIGGER, MotionEvent.AXIS_RTRIGGER
+            };
+            for (int i = 0; i < axisList.length; i++) {
+                final int axis = axisList[i];
+                final InputDevice.MotionRange range = device.getMotionRange(axis, event.getSource());
+                if (range != null) {
+                    final float flat = range.getFlat();
+                    final float value = event.getAxisValue(axis);
+
+                    if (Math.abs(value) > flat) {
+                        queueEvent(new Runnable() {
+                            // This method will be called on the rendering thread:
+                            public void run() {
+                                me.HandleResult(NME.onJoyMotion(deviceId,axis,value));
+                            }});
+                    } else {
+                        queueEvent(new Runnable() {
+                            // This method will be called on the rendering thread:
+                            public void run() {
+                                me.HandleResult(NME.onJoyMotion(deviceId,axis,0));
+                            }});
+                    }
+                }
+            }
+            return true;
+        }
+        return super.onGenericMotionEvent(event);
+    }
+}

--- a/templates/android/template/src/org/haxe/nme/NME.java
+++ b/templates/android/template/src/org/haxe/nme/NME.java
@@ -20,6 +20,7 @@ public class NME {
      public static native int onResize(int width, int height);
      public static native int onTrackball(float x,float y);
      public static native int onJoyChange(int inDeviceID, int inCode, boolean inIsDown);
+     public static native int onJoyMotion(int inDeviceID, int inAxis, float inValue);
      public static native int onKeyChange(int inCode, boolean inIsDown);
      public static native int onRender();
      public static native int onPoll();


### PR DESCRIPTION
Handles joystick axis movement on Android targets using SDK version 12 and above. I picked common axis values to check which covers all of the axes on the Ouya controller. Hopefully that cuts down on the number of JNI calls.

Add ?w=1 to the url to ignore the whitespace changes. I use Sublime Text and it cleans up extra whitespace at the end of lines.
