### PR TITLE
Descender fix. ioMetrics.descent broken and always equal 0.

### DIFF
--- a/project/common/FreeType.cpp
+++ b/project/common/FreeType.cpp
@@ -148,7 +148,7 @@ public:
       {
          FT_Size_Metrics &metrics = mFace->size->metrics;
          ioMetrics.ascent = std::max( ioMetrics.ascent, (float)metrics.ascender/(1<<6) );
-         ioMetrics.descent = std::max( ioMetrics.descent, (float)metrics.descender/(1<<6) );
+         ioMetrics.descent = std::max( ioMetrics.descent, fabs((float)metrics.descender/(1<<6)) );
          ioMetrics.height = std::max( ioMetrics.height, (float)metrics.height/(1<<6) );
       }
    }


### PR DESCRIPTION
Descender usually and practically all the time negative. 

From freetype documentation:

descender -
The typographic descender of the face, expressed in font units. For font formats not having this information, it is set to ‘bbox.yMin’. Note that this field is usually negative. Only relevant for scalable formats.
