### PR TITLE
Support for custom GLSL shaders

### DIFF
--- a/nme/display/Graphics.hx
+++ b/nme/display/Graphics.hx
@@ -153,6 +153,11 @@ class Graphics
       nme_gfx_move_to(nmeHandle, inX, inY);
    }
 
+   public function attachShader(?shader:Shader)
+   {
+      nme_gfx_attach_shader(nmeHandle, (shader == null ? null : shader.nmeHandle));
+   }
+
    inline static public function RGBA(inRGB:Int, inA:Int = 0xff):Int 
    {
       #if (neko && (!haxe3 || neko_v1))
@@ -184,6 +189,7 @@ class Graphics
    private static var nme_gfx_draw_points = Loader.load("nme_gfx_draw_points", -1);
    private static var nme_gfx_draw_round_rect = Loader.load("nme_gfx_draw_round_rect", -1);
    private static var nme_gfx_draw_triangles = Loader.load("nme_gfx_draw_triangles", -1);
+   private static var nme_gfx_attach_shader = Loader.load("nme_gfx_attach_shader", 2);
 }
 
 #else

--- a/nme/display/Shader.hx
+++ b/nme/display/Shader.hx
@@ -1,0 +1,21 @@
+package nme.display;
+
+import nme.Loader;
+
+class Shader
+{
+	/** @private */ public var nmeHandle:Dynamic;
+
+	public function new(inVertSource:String, inFragSource:String)
+	{
+		nmeHandle = nme_shader_create(inVertSource, inFragSource);
+	}
+
+	public function setUniformValue(name:String, value:Dynamic)
+	{
+		nme_shader_set_uniform(nmeHandle, name, value);
+	}
+
+	private static var nme_shader_create = Loader.load("nme_shader_create", 2);
+	private static var nme_shader_set_uniform = Loader.load("nme_shader_set_uniform", 3);
+}

--- a/project/common/ExternalInterface.cpp
+++ b/project/common/ExternalInterface.cpp
@@ -2507,6 +2507,43 @@ value nme_gfx_draw_points(value *arg, int nargs)
 DEFINE_PRIM_MULT(nme_gfx_draw_points);
 
 
+void nme_gfx_attach_shader(value inGfx, value inProgram)
+{
+   Graphics *gfx;
+   GPUProg *prog;
+   if (AbstractToObject(inGfx,gfx))
+   {
+      AbstractToObject(inProgram,prog); // allow null to detach shader
+      gfx->attachShader(prog);
+   }
+}
+DEFINE_PRIM(nme_gfx_attach_shader,2);
+
+value nme_shader_create(value inVert, value inFrag)
+{
+   GPUProg *prog = GPUProg::create(val_string(inVert), val_string(inFrag));
+   return ObjectToAbstract(prog);
+}
+DEFINE_PRIM(nme_shader_create,2);
+
+value nme_shader_set_uniform(value inProgram, value inId, value inValue)
+{
+   GPUProg *prog;
+   if (AbstractToObject(inProgram,prog))
+   {
+      if (val_is_int(inValue))
+      {
+         int val = val_int(inValue);
+         prog->setUniformi(val_string(inId), &val, 1);
+      }
+      else if (val_is_float(inValue))
+      {
+         float val = val_float(inValue);
+         prog->setUniformf(val_string(inId), &val, 1);
+      }
+   }
+}
+DEFINE_PRIM(nme_shader_set_uniform,3);
 
 
 // --- IGraphicsData -----------------------------------------------------

--- a/project/common/Graphics.cpp
+++ b/project/common/Graphics.cpp
@@ -465,6 +465,12 @@ void Graphics::drawTriangles(const QuickVec<float> &inXYs,
    mJobs.push_back(job);
 }
 
+void Graphics::attachShader(GPUProg *prog)
+{
+   // Flush();
+   mFillJob.mProgram = prog;
+   mTileJob.mProgram = prog;
+}
 
 
 // This routine converts a list of "GraphicsPaths" (mItems) into a list

--- a/project/opengl/OGL.h
+++ b/project/opengl/OGL.h
@@ -192,29 +192,6 @@ enum GPUProgID
    gpuSIZE,
 };
 
-typedef float Trans4x4[4][4];
-
-class GPUProg
-{
-public:
-   static GPUProg *create(GPUProgID inID);
-
-   virtual ~GPUProg() {}
-
-   virtual bool bind() = 0;
-
-   virtual void setPositionData(const float *inData, bool inIsPerspective) = 0;
-   virtual void setTexCoordData(const float *inData) = 0;
-   virtual void setColourData(const int *inData) = 0;
-   virtual void setColourTransform(const ColorTransform *inTransform) = 0;
-   virtual int  getTextureSlot() = 0;
-
-   virtual void setTransform(const Trans4x4 &inTrans) = 0;
-   virtual void setTint(unsigned int inColour) = 0;
-   virtual void setGradientFocus(float inFocus) = 0;
-   virtual void finishDrawing() = 0;
-};
-
 void InitOGL2Extensions();
 
 } // end namespace nme

--- a/project/opengl/OGLShaders.cpp
+++ b/project/opengl/OGLShaders.cpp
@@ -154,6 +154,54 @@ public:
       return true;
    }
 
+   void setUniformf(const char *id, float *value, int size)
+   {
+      GLint location = glGetUniformLocation(mProgramId, id);
+      if (location)
+      {
+         glUseProgram(mProgramId);
+         switch (size)
+         {
+            case 1:
+               glUniform1f(location, *value);
+               break;
+            case 2:
+               glUniform2f(location, value[0], value[1]);
+               break;
+            case 3:
+               glUniform3f(location, value[0], value[1], value[2]);
+               break;
+            case 4:
+               glUniform4f(location, value[0], value[1], value[2], value[3]);
+               break;
+         }
+      }
+   }
+
+   void setUniformi(const char *id, int *value, int size)
+   {
+      GLint location = glGetUniformLocation(mProgramId, id);
+      if (location)
+      {
+         glUseProgram(mProgramId);
+         switch (size)
+         {
+            case 1:
+               glUniform1i(location, *value);
+               break;
+            case 2:
+               glUniform2i(location, value[0], value[1]);
+               break;
+            case 3:
+               glUniform3i(location, value[0], value[1], value[2]);
+               break;
+            case 4:
+               glUniform4i(location, value[0], value[1], value[2], value[3]);
+               break;
+         }
+      }
+   }
+
    void setPositionData(const float *inData, bool inIsPerspective)
    {
       glVertexAttribPointer(mVertexSlot, inIsPerspective ? 4 : 2 , GL_FLOAT, GL_FALSE, 0, inData);
@@ -315,202 +363,8 @@ public:
    GLint     mOn2ASlot;
 };
 
-const char *gSolidVert = 
-"uniform mat4 uTransform;\n"
-"attribute vec4 aVertex;\n"
-"void main(void)\n"
-"{\n"
-"   gl_Position = aVertex * uTransform;\n"
-"}";
-
-const char *gColourVert =
-"uniform mat4 uTransform;\n"
-"attribute vec4 aVertex;\n"
-"attribute vec4 aColourArray;\n"
-"varying vec4 vColourArray;\n"
-"void main(void)\n"
-"{\n"
-"   vColourArray = aColourArray;\n"
-"   gl_Position = aVertex * uTransform;\n"
-"}";
-
-
-const char *gTextureVert =
-"uniform mat4 uTransform;\n"
-"attribute vec4 aVertex;\n"
-"attribute vec2 aTexCoord;\n"
-"varying vec2 vTexCoord;\n"
-"void main(void)\n"
-"{\n"
-"   vTexCoord = aTexCoord;\n"
-"   gl_Position = aVertex * uTransform;\n"
-"}";
-
-
-const char *gTextureColourVert =
-"uniform mat4 uTransform;\n"
-"attribute vec4 aColourArray;\n"
-"attribute vec4 aVertex;\n"
-"attribute vec2 aTexCoord;\n"
-"varying vec2   vTexCoord;\n"
-"varying vec4  vColourArray;\n"
-"void main(void)\n"
-"{\n"
-"   vColourArray = aColourArray;\n"
-"   vTexCoord = aTexCoord;\n"
-"   gl_Position = aVertex * uTransform;\n"
-"}";
-
-
-
-const char *gSolidFrag = 
-"uniform vec4 uTint;\n"
-"void main(void)\n"
-"{\n"
-"   gl_FragColor = uTint;\n"
-"}\n";
-
-const char *gColourFrag =
-"varying vec4 vColourArray;\n"
-"void main(void)\n"
-"{\n"
-"   gl_FragColor = vColourArray;\n"
-"}\n";
-
-
-const char *gColourTransFrag =
-"varying vec4 vColourArray;\n"
-"uniform vec4 uColourScale;\n"
-"uniform vec4 uColourOffset;\n"
-"void main(void)\n"
-"{\n"
-"   gl_FragColor = vColourArray*uColourScale+uColourOffset;\n"
-"}\n";
-
-
-
-const char *gBitmapAlphaFrag =
-"varying vec2 vTexCoord;\n"
-"uniform sampler2D uImage0;\n"
-"uniform vec4 uTint;\n"
-"void main(void)\n"
-"{\n"
-#ifdef NME_PREMULTIPLIED_ALPHA
-"   gl_FragColor.rgb = uTint.rgb*texture2D(uImage0,vTexCoord).a;\n"
-#else
-"   gl_FragColor.rgb = uTint.rgb;\n"
-#endif
-"   gl_FragColor.a = texture2D(uImage0,vTexCoord).a*uTint.a;\n"
-"}\n";
-
-
-const char *gBitmapFrag =
-"varying vec2 vTexCoord;\n"
-"uniform sampler2D uImage0;\n"
-"uniform vec4 uTint;\n"
-"void main(void)\n"
-"{\n"
-"   gl_FragColor = texture2D(uImage0,vTexCoord)*uTint;\n"
-"}\n";
-
-
-const char *gTextureFrag =
-"varying vec2 vTexCoord;\n"
-"uniform sampler2D uImage0;\n"
-"void main(void)\n"
-"{\n"
-"   gl_FragColor = texture2D(uImage0,vTexCoord);\n"
-"}\n";
-
-
-const char *gRadialTextureFrag =
-"varying vec2 vTexCoord;\n"
-"uniform sampler2D uImage0;\n"
-"void main(void)\n"
-"{\n"
-"   float rad = sqrt(vTexCoord.x*vTexCoord.x + vTexCoord.y*vTexCoord.y);\n"
-"   gl_FragColor = texture2D(uImage0,vec2(rad,0));\n"
-"}\n";
-
-
-const char *gRadialFocusTextureFrag =
-"varying vec2 vTexCoord;\n"
-"uniform sampler2D uImage0;\n"
-"uniform float mA;\n"
-"uniform float mFX;\n"
-"uniform float mOn2A;\n"
-"void main(void)\n"
-"{\n"
-"   float GX = vTexCoord.x - mFX;\n"
-"   float C = GX*GX + vTexCoord.y*vTexCoord.y;\n"
-"   float B = 2.0*GX * mFX;\n"
-"   float det =B*B - mA*C;\n"
-"   float rad;\n"
-"   if (det<0.0)\n"
-"      rad = -B * mOn2A;\n"
-"   else\n"
-"      rad = (-B - sqrt(det)) * mOn2A;"
-"   gl_FragColor = texture2D(uImage0,vec2(rad,0));\n"
-"}\n";
-
-
-const char *gTextureColourFrag =
-"uniform sampler2D uImage0;\n"
-"varying vec2 vTexCoord;\n"
-"varying vec4 vColourArray;\n"
-"void main(void)\n"
-"{\n"
-#ifdef NME_PREMULTIPLIED_ALPHA
-"   gl_FragColor.rgb = texture2D(uImage0,vTexCoord).rgb * vColourArray.rgb * vColourArray.a;\n"
-"   gl_FragColor.a = texture2D(uImage0,vTexCoord).a * vColourArray.a;\n"
-#else
-"   gl_FragColor = texture2D(uImage0,vTexCoord) * vColourArray;\n"
-#endif
-"}\n";
-
-
-
-const char *gTextureTransFrag =
-"varying vec2 vTexCoord;\n"
-"uniform sampler2D uImage0;\n"
-"uniform vec4 uColourScale;\n"
-"uniform vec4 uColourOffset;\n"
-"void main(void)\n"
-"{\n"
-"   gl_FragColor = texture2D(uImage0,vTexCoord) * uColourScale + uColourOffset;\n"
-"}\n";
-
-
-
-
-GPUProg *GPUProg::create(GPUProgID inID)
-{
-   switch(inID)
-   {
-      case gpuSolid:
-         return new OGLProg( gSolidVert, gSolidFrag );
-      case gpuColourTransform:
-         return new OGLProg( gColourVert, gColourTransFrag );
-      case gpuColour:
-         return new OGLProg( gColourVert, gColourFrag );
-      case gpuRadialGradient:
-         return new OGLProg( gTextureVert, gRadialTextureFrag );
-      case gpuRadialFocusGradient:
-         return new OGLProg( gTextureVert, gRadialFocusTextureFrag );
-      case gpuTexture:
-         return new OGLProg( gTextureVert, gTextureFrag );
-      case gpuTextureColourArray:
-         return new OGLProg( gTextureColourVert, gTextureColourFrag );
-      case gpuTextureTransform:
-         return new OGLProg( gTextureVert, gTextureTransFrag );
-      case gpuBitmap:
-         return new OGLProg( gTextureVert, gBitmapFrag );
-      case gpuBitmapAlpha:
-         return new OGLProg( gTextureVert, gBitmapAlphaFrag );
-      default:
-        break;
-   }
-   return 0;
+GPUProg *GPUProg::create(const char *inVertSource, const char *inFragSource) {
+  return new OGLProg(inVertSource, inFragSource);
 }
 
 } // end namespace nme
@@ -519,7 +373,7 @@ GPUProg *GPUProg::create(GPUProgID inID)
 
 namespace nme
 {
-GPUProg *GPUProg::create(GPUProgID inID) { return 0; }
+  GPUProg *GPUProg::create(const char *inVertSource, const char *inFragSource) { return 0; }
 }
 
 #endif

--- a/project/opengl/OGLShaders.h
+++ b/project/opengl/OGLShaders.h
@@ -1,0 +1,174 @@
+#ifndef OGLSHADERS_H
+#define OGLSHADERS_H
+
+namespace nme
+{
+
+const char *gSolidVert = 
+"uniform mat4 uTransform;\n"
+"attribute vec4 aVertex;\n"
+"void main(void)\n"
+"{\n"
+"   gl_Position = aVertex * uTransform;\n"
+"}";
+
+const char *gColourVert =
+"uniform mat4 uTransform;\n"
+"attribute vec4 aVertex;\n"
+"attribute vec4 aColourArray;\n"
+"varying vec4 vColourArray;\n"
+"void main(void)\n"
+"{\n"
+"   vColourArray = aColourArray;\n"
+"   gl_Position = aVertex * uTransform;\n"
+"}";
+
+
+const char *gTextureVert =
+"uniform mat4 uTransform;\n"
+"attribute vec4 aVertex;\n"
+"attribute vec2 aTexCoord;\n"
+"varying vec2 vTexCoord;\n"
+"void main(void)\n"
+"{\n"
+"   vTexCoord = aTexCoord;\n"
+"   gl_Position = aVertex * uTransform;\n"
+"}";
+
+
+const char *gTextureColourVert =
+"uniform mat4 uTransform;\n"
+"attribute vec4 aColourArray;\n"
+"attribute vec4 aVertex;\n"
+"attribute vec2 aTexCoord;\n"
+"varying vec2   vTexCoord;\n"
+"varying vec4  vColourArray;\n"
+"void main(void)\n"
+"{\n"
+"   vColourArray = aColourArray;\n"
+"   vTexCoord = aTexCoord;\n"
+"   gl_Position = aVertex * uTransform;\n"
+"}";
+
+
+
+const char *gSolidFrag = 
+"uniform vec4 uTint;\n"
+"void main(void)\n"
+"{\n"
+"   gl_FragColor = uTint;\n"
+"}\n";
+
+const char *gColourFrag =
+"varying vec4 vColourArray;\n"
+"void main(void)\n"
+"{\n"
+"   gl_FragColor = vColourArray;\n"
+"}\n";
+
+
+const char *gColourTransFrag =
+"varying vec4 vColourArray;\n"
+"uniform vec4 uColourScale;\n"
+"uniform vec4 uColourOffset;\n"
+"void main(void)\n"
+"{\n"
+"   gl_FragColor = vColourArray*uColourScale+uColourOffset;\n"
+"}\n";
+
+
+
+const char *gBitmapAlphaFrag =
+"varying vec2 vTexCoord;\n"
+"uniform sampler2D uImage0;\n"
+"uniform vec4 uTint;\n"
+"void main(void)\n"
+"{\n"
+#ifdef NME_PREMULTIPLIED_ALPHA
+"   gl_FragColor.rgb = uTint.rgb*texture2D(uImage0,vTexCoord).a;\n"
+#else
+"   gl_FragColor.rgb = uTint.rgb;\n"
+#endif
+"   gl_FragColor.a = texture2D(uImage0,vTexCoord).a*uTint.a;\n"
+"}\n";
+
+
+const char *gBitmapFrag =
+"varying vec2 vTexCoord;\n"
+"uniform sampler2D uImage0;\n"
+"uniform vec4 uTint;\n"
+"void main(void)\n"
+"{\n"
+"   gl_FragColor = texture2D(uImage0,vTexCoord)*uTint;\n"
+"}\n";
+
+
+const char *gTextureFrag =
+"varying vec2 vTexCoord;\n"
+"uniform sampler2D uImage0;\n"
+"void main(void)\n"
+"{\n"
+"   gl_FragColor = texture2D(uImage0,vTexCoord);\n"
+"}\n";
+
+
+const char *gRadialTextureFrag =
+"varying vec2 vTexCoord;\n"
+"uniform sampler2D uImage0;\n"
+"void main(void)\n"
+"{\n"
+"   float rad = sqrt(vTexCoord.x*vTexCoord.x + vTexCoord.y*vTexCoord.y);\n"
+"   gl_FragColor = texture2D(uImage0,vec2(rad,0));\n"
+"}\n";
+
+
+const char *gRadialFocusTextureFrag =
+"varying vec2 vTexCoord;\n"
+"uniform sampler2D uImage0;\n"
+"uniform float mA;\n"
+"uniform float mFX;\n"
+"uniform float mOn2A;\n"
+"void main(void)\n"
+"{\n"
+"   float GX = vTexCoord.x - mFX;\n"
+"   float C = GX*GX + vTexCoord.y*vTexCoord.y;\n"
+"   float B = 2.0*GX * mFX;\n"
+"   float det =B*B - mA*C;\n"
+"   float rad;\n"
+"   if (det<0.0)\n"
+"      rad = -B * mOn2A;\n"
+"   else\n"
+"      rad = (-B - sqrt(det)) * mOn2A;"
+"   gl_FragColor = texture2D(uImage0,vec2(rad,0));\n"
+"}\n";
+
+
+const char *gTextureColourFrag =
+"uniform sampler2D uImage0;\n"
+"varying vec2 vTexCoord;\n"
+"varying vec4 vColourArray;\n"
+"void main(void)\n"
+"{\n"
+#ifdef NME_PREMULTIPLIED_ALPHA
+"   gl_FragColor.rgb = texture2D(uImage0,vTexCoord).rgb * vColourArray.rgb * vColourArray.a;\n"
+"   gl_FragColor.a = texture2D(uImage0,vTexCoord).a * vColourArray.a;\n"
+#else
+"   gl_FragColor = texture2D(uImage0,vTexCoord) * vColourArray;\n"
+#endif
+"}\n";
+
+
+
+const char *gTextureTransFrag =
+"varying vec2 vTexCoord;\n"
+"uniform sampler2D uImage0;\n"
+"uniform vec4 uColourScale;\n"
+"uniform vec4 uColourOffset;\n"
+"void main(void)\n"
+"{\n"
+"   gl_FragColor = texture2D(uImage0,vTexCoord) * uColourScale + uColourOffset;\n"
+"}\n";
+
+}
+
+#endif

--- a/samples/25-Shaders/Sample.hx
+++ b/samples/25-Shaders/Sample.hx
@@ -1,0 +1,52 @@
+import nme.display.Sprite;
+import nme.display.Shader;
+import nme.events.Event;
+
+class Sample extends Sprite
+{
+	public function new()
+	{
+		super();
+		shader = new Shader("uniform mat4 uTransform;
+			attribute vec4 aVertex;
+			void main() { gl_Position = aVertex * uTransform; }",
+			"uniform float uTimer;
+			void main() { gl_FragColor = vec4(sin(uTimer), 0, 0, 1); }");
+
+		shader2 = new Shader("uniform mat4 uTransform;
+			attribute vec4 aVertex;
+			void main() { gl_Position = aVertex * uTransform; }",
+			"void main() { gl_FragColor = vec4(1, 1, 0, 1); }");
+
+		// shader.setUniformValue("uVector", [0, 1, 2]);
+
+		graphics.beginFill(0xFFFFFF);
+		graphics.drawRect(0, 0, 50, 50);
+		graphics.endFill();
+
+		graphics.attachShader(shader);
+		graphics.beginFill(0xFFFFFF);
+		graphics.drawRect(50, 0, 50, 50);
+		graphics.endFill();
+
+		graphics.beginFill(0x0f0f0f);
+		graphics.attachShader(shader2);
+		graphics.drawRect(100, 0, 50, 50);
+
+		graphics.attachShader(); // detach
+		graphics.drawRect(150, 0, 50, 50);
+		graphics.endFill();
+
+		startTime = nme.Lib.getTimer();
+		addEventListener(Event.ENTER_FRAME, onEnterFrame);
+	}
+
+	private function onEnterFrame(e:Event)
+	{
+		shader.setUniformValue("uTimer", (nme.Lib.getTimer() - startTime) / 1000);
+	}
+
+	private var startTime:Int;
+	private var shader:Shader;
+	private var shader2:Shader;
+}

--- a/samples/25-Shaders/Sample.nmml
+++ b/samples/25-Shaders/Sample.nmml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<project>
+
+  <app
+     file="Sample25"
+     title="NME Sample 25 - Shaders"
+     package="org.haxe.nme.sample25"
+     version="1.0.0"
+     company="nme"
+     main="Sample"
+  />
+
+  <window
+      width="640"
+      height="480"
+      orientation="landscape"
+      fps="60"
+      background="0x222222"
+      resizable="true"
+      hardware="true"
+  />
+
+
+  <classpath name="." />
+  <haxelib name="nme" />
+  <icon name="../common/nme.svg" />
+
+
+  <ndll name="std" />
+  <ndll name="regexp" />
+  <ndll name="zlib" />
+  <ndll name="nme" haxelib="nme" />
+
+  <haxedef name="no_console" />
+
+</project>


### PR DESCRIPTION
I've added the ability to attach custom GLSL shaders and set basic uniform values (float, int, vec2/3/4). This required me to move the base GL shaders and the GPUProg class. I also created a sample project to test attaching and detaching shaders by setting it to null.

Eventually it would be nice to handle attributes, uniform matrices, and textures but I felt like this pull request was large enough as it is.
