### PR TITLE
nme_gl_uniform_matrix only works when count = 4

### DIFF
--- a/project/opengl/OGLExport.cpp
+++ b/project/opengl/OGLExport.cpp
@@ -668,7 +668,7 @@ value nme_gl_uniform_matrix(value inLocation, value inTranspose, value inBytes,v
    ByteArray bytes(inBytes);
    int size = bytes.Size();
 
-   if (size>=count*4*4)
+   if (size==count*count*4)
    {
       const float *data = (float *)bytes.Bytes();
 


### PR DESCRIPTION
nme_gl_uniform_matrix was incorrectly checking the size of inBytes, consequently GL.uniformMatrix2fv, GL.uniformMatrix3fv in openfl were non-functional
