### PR TITLE
Added keyboardObserver for iOS devices.

### DIFF
--- a/project/iPhone/UIStageView.mm
+++ b/project/iPhone/UIStageView.mm
@@ -86,6 +86,7 @@ namespace nme { int gFixedOrientation = -1; }
 
 @property (readonly, nonatomic, getter=isAnimating) BOOL animating;
 @property (nonatomic) NSInteger animationFrameInterval;
+@property (nonatomic, retain, readwrite) id keyboardObserver;
 
 - (void) myInit;
 - (void) drawView:(id)sender;
@@ -833,6 +834,7 @@ public:
 @implementation UIStageView
 
 @synthesize animating;
+@synthesize keyboardObserver = _keyboardObserver;
 @dynamic animationFrameInterval;
 
 // You must implement this method
@@ -1181,10 +1183,21 @@ public:
 	     [self addSubview: mTextField];
 
           }
+          if (!self.keyboardObserver) {
+               self.keyboardObserver = [[NSNotificationCenter defaultCenter] addObserverForName:UIKeyboardWillHideNotification object:nil queue:nil usingBlock:^(NSNotification* notification) {
+                   printf("Got a notify.\n");
+                   mStage->SetFocusObject(0);
+                   [self enableKeyboard:NO];
+                }];
+             }
           [mTextField becomeFirstResponder];
        }
        else
        {
+          if (self.keyboardObserver) {
+             [[NSNotificationCenter defaultCenter] removeObserver:self.keyboardObserver];
+             self.keyboardObserver = nil;
+          }
           [mTextField resignFirstResponder];
        }
    }


### PR DESCRIPTION
It was possible to close the keyboard on tablets without loosing focus on textfields. That is not the native behaviour. When keyboard is invisble no textfield can be focused (besides using a bluetooth keyboard).
