### PR TITLE
JNI parameter type checking fix

### DIFF
--- a/project/android/JNI.cpp
+++ b/project/android/JNI.cpp
@@ -355,7 +355,6 @@ value JObjectToHaxe(JNIEnv *inEnv,JNIType inType,jobject inObject)
    if (inType.isUnknownType())
    {
       jclass cls = inEnv->GetObjectClass(inObject);
-      CheckException(inEnv,true);
       if (cls)
       { 
 


### PR DESCRIPTION
The core problem I found was that jclass variables were compared using equals (==) operator assuming it could be used like that.  I think that after the JNI changes in ICS this is no longer true.  I solved the issue by using the IsSameObject() function on 2 jclass variables.
- Use the global FindClass() function when you need a class.  This global function looks up the class and also creates a global reference.  It also keeps a registry so there only needs to be one global reference.
- Use IsSameObject between class objects to compare classes.
