### PR TITLE
Correct way to hide status bar on IOS7 when window fullscreen=true

### DIFF
--- a/templates/iphone/PROJ/PROJ-Info.plist
+++ b/templates/iphone/PROJ/PROJ-Info.plist
@@ -53,6 +53,8 @@
 	<true/>
 	<key>UIStatusBarHidden</key>
 	<::WIN_FULLSCREEN::/>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<::!WIN_FULLSCREEN::/>
 	::if (IOS_APP_ORIENTATION != null)::
 	<key>UISupportedInterfaceOrientations</key>
 	::IOS_APP_ORIENTATION::::end::


### PR DESCRIPTION
P.S. I think its broken on openfl too, UIViewControllerBasedStatusBarAppearance should be !WIN_FULLSCREEN
