### PR TITLE
Proper comparison of userAgent string for no user input

### DIFF
--- a/project/src/common/CURL.cpp
+++ b/project/src/common/CURL.cpp
@@ -167,7 +167,8 @@ public:
 
       /* some servers don't like requests that are made without a user-agent
          field, so we provide one */
-      curl_easy_setopt(mHandle, CURLOPT_USERAGENT, r.userAgent != 0 ? r.userAgent : "libcurl-agent/1.0");
+      const char* userAgent = strcmp(r.userAgent, "") ? r.userAgent : "libcurl-agent/1.0";
+      curl_easy_setopt(mHandle, CURLOPT_USERAGENT, userAgent);
 
       mState = urlLoading;
 


### PR DESCRIPTION
The previous PR didn't compare the string properly.  It was checking for a null pointer but the val_string method will default strings to an empty string.  Therefore strcmp needs to be used to compare the input string with "".
