### PR TITLE
Fix TextField clipping When Scaling Horizontally.

### DIFF
--- a/project/src/common/TextField.cpp
+++ b/project/src/common/TextField.cpp
@@ -1387,7 +1387,7 @@ void TextField::Render( const RenderTarget &inTarget, const RenderState &inState
 
    RenderState state(inState);
 
-   Rect r = mActiveRect.Rotated(mLayoutRotation).Translated(matrix.mtx,matrix.mty).RemoveBorder(2*mLayoutScaleH);
+   Rect r = mActiveRect.Rotated(mLayoutRotation).Translated(matrix.mtx,matrix.mty).RemoveBorder(2*mLayoutScaleV);
    state.mClipRect = r.Intersect(inState.mClipRect);
 
    if (inState.mMask)


### PR DESCRIPTION
Currently when you scale a TextField horizontally, it will begin to clip the text until nothing is visible.  This PR is an attempt to fix this.

**NOTE:** I really do not have a full grasp of what is going on in TextField.cpp and would appreciate a good review of this before it gets merged.

Please have a look at this sample project that exhibits this issue.  It doesn't occur when applying the changes in this PR.  https://github.com/JandyCo/TextScaleTest

This PR addresses openfl/openfl-native#224.
