### PR TITLE
Fixed transparent blue screen (NME without OpenGL)

### DIFF
--- a/project/src/sdl2/SDL2Stage.cpp
+++ b/project/src/sdl2/SDL2Stage.cpp
@@ -252,7 +252,7 @@ public:
       else
       {
          mOpenGLContext = 0;
-         mSoftwareSurface = SDL_CreateRGBSurface(0, mWidth, mHeight, 32, 0xFF000000, 0x00FF0000, 0x0000FF00, 0x000000FF);
+         mSoftwareSurface = SDL_CreateRGBSurface(0, mWidth, mHeight, 32, 0x00FF0000, 0x0000FF00, 0x000000FF, 0xFF000000);
          if (!mSoftwareSurface)
          {
             fprintf(stderr, "Could not create SDL surface : %s\n", SDL_GetError());
@@ -308,7 +308,7 @@ public:
          SDL_FreeSurface(mSoftwareSurface);
          SDL_DestroyTexture(mSoftwareTexture);
          
-         mSoftwareSurface = SDL_CreateRGBSurface(0, mWidth, mHeight, 32, 0xFF000000, 0x00FF0000, 0x0000FF00, 0x000000FF);
+         mSoftwareSurface = SDL_CreateRGBSurface(0, mWidth, mHeight, 32, 0x00FF0000, 0x0000FF00, 0x000000FF, 0xFF000000);
          if (!mSoftwareSurface)
          {
             fprintf(stderr, "Could not create SDL surface : %s\n", SDL_GetError());


### PR DESCRIPTION
For some unrelated reason, I don't have OpenGL on my Windows 8.1. Therefore, OpenFL/NME will fallback to a without-OpenGL mode, and use SDL for this. **To test this or reproduce the bug, you have to disable OpenGL somehow**.

In this case however, my OpenFL window was blue, and the drawings not erased (for instance, antialiased text would get pixellised because semi-transparent antialias sums up until it becomes opaque).

I investigated, and it was in fact that somehow the alpha channel of the background color was interpreted as the blue channel, and the other colors were also swapped.

Then I found that the SDL surface was created with custom color masks, and changing them fixed the problem **on my computer**. I didn't have the occasion to test this on other targets yet.
