### PR TITLE
Use semi circle sound panning in all places where sound transform is changed

### DIFF
--- a/project/src/openal/OpenALSound.cpp
+++ b/project/src/openal/OpenALSound.cpp
@@ -405,7 +405,7 @@ namespace nme
       else
       {
          alSourcef(mSourceID, AL_GAIN, inTransform.volume);
-         alSource3f(mSourceID, AL_POSITION, inTransform.pan * 1, 0, 0);
+         alSource3f(mSourceID, AL_POSITION, (float) cos((inTransform.pan - 1) * (1.5707)), 0, (float) sin((inTransform.pan + 1) * (1.5707)));
       }
    }
    


### PR DESCRIPTION
See https://github.com/openfl/lime/pull/15 for original change. Original change didn't cover the all the cases where sound transform is modified after creating the sound.
