### PR TITLE
Allow single sample buffer for alpha2coverage

### DIFF
--- a/templates/android/PROJ/src/org/haxe/nme/MainView.java
+++ b/templates/android/PROJ/src/org/haxe/nme/MainView.java
@@ -117,7 +117,7 @@ class MainView extends GLSurfaceView {
 
 
                 // Try as specified - aa
-                if (::WIN_ANTIALIASING:: > 1)
+                if (::WIN_ANTIALIASING:: >= 1)
                 {
                    int[] attrs = { EGL10.EGL_DEPTH_SIZE, depth,
                                    EGL10.EGL_STENCIL_SIZE, stencil,


### PR DESCRIPTION
When antialiasing =1 create the samples buffer to allow alphaToCoverage

ref : https://github.com/haxenme/nme/issues/152
