### PR TITLE
Fix for rtt ios

### DIFF
--- a/project/src/opengl/OGLExport.cpp
+++ b/project/src/opengl/OGLExport.cpp
@@ -242,6 +242,8 @@ public:
    ResoType type;
 };
 
+static int screenBuffer = -1;
+
 value createResource(unsigned int inResource, ResoType inType)
 {
    value result = ObjectToAbstract( new NmeResource(inResource,inType) );
@@ -453,6 +455,9 @@ value nme_gl_get_parameter(value pname_val)
       // case GL_RENDERBUFFER_BINDING  WebGLRenderbuffer
       // case GL_TEXTURE_BINDING_2D  WebGLTexture
       // case GL_TEXTURE_BINDING_CUBE_MAP  WebGLTexture
+	  case GL_FRAMEBUFFER_BINDING  : ints = 1; break;
+	  case GL_RENDERBUFFER_BINDING  : ints = 1; break;
+      case GL_TEXTURE_BINDING_2D  : ints = 1; break;
 
       case GL_DEPTH_CLEAR_VALUE:
       case GL_LINE_WIDTH:
@@ -1492,10 +1497,15 @@ DEFINE_PRIM(nme_gl_get_buffer_parameter,2);
 value nme_gl_bind_framebuffer(value target, value framebuffer)
 {
    DBGFUNC("bindFramebuffer");
-   if (CHECK_EXT(glBindFramebuffer))
-   {
-      int id = getResource(framebuffer,resoFramebuffer);
-      glBindFramebuffer(val_int(target), id );
+   if (CHECK_EXT(glBindFramebuffer)){
+         if( screenBuffer == -1 ) screenBuffer = val_int(nme_gl_get_parameter( alloc_int(GL_FRAMEBUFFER_BINDING )));
+	   
+      if( val_is_null(framebuffer) )
+         glBindFramebuffer(val_int(target), screenBuffer );
+      else {
+         int id = getResource(framebuffer,resoFramebuffer);
+         glBindFramebuffer(val_int(target), id );
+	  }
    }
    return alloc_null();
 }


### PR DESCRIPTION
Hi bros,

I took some time to send a PR to youto enable  nme/lime/openfl users to have properly fuctionning render to texture.

Basically I snatch the "root framebuffer" in ios. This is mandatory as ios does not have an opengl compliant policy. (app backbuffers are not the framebuffer 0)

note : My commit are ugly because merging files with 3-space as tabs ( erk)+ git merge = deah...

Thanks.