### PR TITLE
Borrow fixed orientation handling from NME

### DIFF
--- a/project/src/iPhone/UIStageView.mm
+++ b/project/src/iPhone/UIStageView.mm
@@ -3052,7 +3052,29 @@ public:
 - (BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)interfaceOrientation
 {
    if (gFixedOrientation >= 0)
-      return interfaceOrientation == gFixedOrientation;
+   {
+      enum {
+         OrientationPortrait = 1,
+         OrientationPortraitUpsideDown = 2,
+         OrientationLandscapeRight = 3,
+         OrientationLandscapeLeft = 4,
+         OrientationFaceUp = 5,
+         OrientationFaceDown = 6,
+         OrientationPortraitAny = 7,
+         OrientationLandscapeAny = 8,
+         OrientationAny = 9,
+      };
+
+      if (interfaceOrientation == gFixedOrientation)
+         return true;
+      if (gFixedOrientation==OrientationAny)
+         return true;
+      if (gFixedOrientation==OrientationPortraitAny)
+         return interfaceOrientation==OrientationPortrait || interfaceOrientation==OrientationPortraitUpsideDown;
+      if (gFixedOrientation==OrientationLandscapeAny)
+         return interfaceOrientation==OrientationLandscapeLeft || interfaceOrientation==OrientationLandscapeRight;
+      return false;
+   }
    Event evt(etShouldRotate);
    evt.value = interfaceOrientation;
    sgMainView->mStage->OnEvent(evt);


### PR DESCRIPTION
so that on iOS orientation can be configured before the stage is created.  See also https://github.com/haxenme/nme/commit/b7698f25d30d45d13c780f33567973772cca01f6.

Stage.shouldRotateInterface() cannot be used to indicate initial orientation preference on iOS, because it is not called unless the stage has been instantiated, and UIStageViewController.supportedInterfaceOrientations() is called before the stage is created.
