### PR TITLE
add dead zone low filter for joystick axis motions

### DIFF
--- a/project/src/sdl2/SDL2Stage.cpp
+++ b/project/src/sdl2/SDL2Stage.cpp
@@ -1286,7 +1286,8 @@ void ProcessEvent(SDL_Event &inEvent)
          {
             sgJoysticksAxisMap[inEvent.jaxis.which][inEvent.jaxis.axis] = inEvent.jaxis.value;
          }
-         else if (sgJoysticksAxisMap[inEvent.jaxis.which][inEvent.jaxis.axis] == inEvent.jaxis.value) {
+         else if (sgJoysticksAxisMap[inEvent.jaxis.which][inEvent.jaxis.axis] == inEvent.jaxis.value)
+         {
             break;
          }
          if (inEvent.jaxis.value > -sgJoystickDeadZone && inEvent.jaxis.value < sgJoystickDeadZone)


### PR DESCRIPTION
Added dead zone low filter for joystick axis motions, removing unnecessary spam from joystick analog sticks.
Base filter set default at value 1000. Tested with multiple gamepads connected at the same time (Sony PS3).
