### PR TITLE
Ios other linker flags

### DIFF
--- a/templates/ios/PROJ.xcodeproj/project.pbxproj
+++ b/templates/ios/PROJ.xcodeproj/project.pbxproj
@@ -344,6 +344,8 @@
 					::end::
 					"-lApplicationMain",
 					::IOS_LINKER_FLAGS::
+					::foreach otherLinkerFlags:: "::__current__::",
+					::end::
 				);
 			};
 			name = Debug;

--- a/templates/ios/PROJ.xcodeproj/project.pbxproj
+++ b/templates/ios/PROJ.xcodeproj/project.pbxproj
@@ -381,7 +381,7 @@
 					"\"$(SRCROOT)/::APP_FILE::/lib/x86_64\"",
 				);
 				OTHER_LDFLAGS = (
-					::foreach ndlls:: "-l::name::",
+					::foreach ndlls:: ::if (importStatic==""):: "-l::name::", ::end::
 					::end::
 					::foreach linkedLibraries:: "::__current__::",
 					::end::

--- a/templates/ios/PROJ.xcodeproj/project.pbxproj
+++ b/templates/ios/PROJ.xcodeproj/project.pbxproj
@@ -389,6 +389,8 @@
 					::end::
 					"-lApplicationMain",
 					::IOS_LINKER_FLAGS::
+					::foreach otherLinkerFlags:: "::__current__::",
+					::end::
 				);
 			};
 			name = Release;

--- a/tools/nme/src/platforms/IOSPlatform.hx
+++ b/tools/nme/src/platforms/IOSPlatform.hx
@@ -210,6 +210,8 @@ class IOSPlatform extends Platform
       context.IOS_COMPILER = config.compiler;
       context.IOS_LINKER_FLAGS = config.linkerFlags.split(" ").join(", ");
 
+      context.otherLinkerFlags = project.otherLinkerFlags;
+
       context.MACROS = {};
       context.MACROS.launchImage = createLaunchImage;
       context.MACROS.appIcon = createAppIcon;

--- a/tools/nme/src/project/NMEProject.hx
+++ b/tools/nme/src/project/NMEProject.hx
@@ -119,6 +119,7 @@ class NMEProject
 
    // Currently for adding frameworks to ios project, or android library projects
    public var dependencies:Map<String,Dependency>;
+   public var otherLinkerFlags:Array<String>;
    // Additional files to be copied into andoird project
    public var javaPaths:Array<String>;
    // Android signing certificate
@@ -172,6 +173,7 @@ class NMEProject
 
       assets = new Array<Asset>();
       dependencies = new Map<String,Dependency>();
+      otherLinkerFlags = [];
       haxedefs = new Map<String,String>();
       haxeflags = new Array<String>();
       macros = new Array<String>();

--- a/tools/nme/src/project/NMMLParser.hx
+++ b/tools/nme/src/project/NMMLParser.hx
@@ -879,6 +879,10 @@ class NMMLParser
                      project.dependencies.set(key, new Dependency(name,path,extensionPath));
                   }
 
+                case "otherLinkerFlags":
+                    var value = element.has.value ? substitute(element.att.value) : "";
+                    project.otherLinkerFlags.push(value);
+
                case "engine":
                   project.engines.set(substitute(element.att.name),
                                       substitute(element.att.version));


### PR DESCRIPTION
This allows me to set the -ObjC flag which is required for haxe-applovin on ios. I also modified project.pbxproj. With the -ObjC flag duplicate symbols will exist unless the ::if (importStatic==""):: is present.