### PR TITLE
Add debug to defines so it could be used in nmml file

### DIFF
--- a/tools/nme/src/CommandLineTools.hx
+++ b/tools/nme/src/CommandLineTools.hx
@@ -1259,7 +1259,7 @@ class CommandLineTools
 
       if (storeData.debug!=null)
       {
-         project.debug = debug = true;
+         project.setDebug(debug = true);
          Log.verbose("Using debug option from setting");
       }
 
@@ -1497,7 +1497,7 @@ class CommandLineTools
                else if (field == "xcodeconfig" ) 
                {
                   if (argValue=="Debug")
-                     project.debug = debug = true;
+                     project.setDebug(debug = true);
                }
                else
                   project.localDefines.set(field, argValue);
@@ -1584,10 +1584,10 @@ class CommandLineTools
 
             else if (argument == "-debug") 
             {
-               project.debug = debug = true;
+               project.setDebug(debug = true);
             }
-            else if (argument == "-megatrace") 
-               project.megaTrace = project.debug = debug = true;
+            else if (argument == "-megatrace")
+               project.setDebug(project.megaTrace = debug = true);
 
             else
                project.targetFlags.set(argument.substr(1), "");

--- a/tools/nme/src/project/NMEProject.hx
+++ b/tools/nme/src/project/NMEProject.hx
@@ -191,6 +191,15 @@ class NMEProject
       exportFilter = "^(class|enum|interface)";
    }
 
+   public function setDebug(inDebug:Bool)
+   {
+      debug = inDebug;
+      if (debug)
+         localDefines.set("debug", "1");
+      else if (localDefines.exists("debug"))
+         localDefines.remove("debug");
+   }
+
    public function setCommand(inCommand:String)
    {
       command = inCommand;


### PR DESCRIPTION
Now debug property on `NMEPRoject` is set through `setDebug` which creates or removes local define.
This will allow to do `if="debug"` and `unless="debug"` in `project.nmml`