### PR TITLE
Made filters' fields public, to be consistent with Flash API

### DIFF
--- a/nme/filters/BlurFilter.hx
+++ b/nme/filters/BlurFilter.hx
@@ -4,9 +4,9 @@ package nme.filters;
 @:nativeProperty
 class BlurFilter extends BitmapFilter 
 {
-   /** @private */ private var blurX:Float;
-   /** @private */ private var blurY:Float;
-   /** @private */ private var quality:Int;
+   public var blurX:Float;
+   public var blurY:Float;
+   public var quality:Int;
    public function new(inBlurX:Float = 4.0, inBlurY:Float = 4.0, inQuality:Int = 1) 
    {
       super("BlurFilter");

--- a/nme/filters/ColorMatrixFilter.hx
+++ b/nme/filters/ColorMatrixFilter.hx
@@ -4,7 +4,7 @@ package nme.filters;
 @:nativeProperty
 class ColorMatrixFilter extends BitmapFilter 
 {
-   /** @private */ private var matrix:Array<Float>;
+   public var matrix:Array<Float>;
    public function new(inMatrix:Array<Float>) 
    {
       super("ColorMatrixFilter");

--- a/nme/filters/DropShadowFilter.hx
+++ b/nme/filters/DropShadowFilter.hx
@@ -4,17 +4,17 @@ package nme.filters;
 @:nativeProperty
 class DropShadowFilter extends BitmapFilter 
 {
-   /** @private */ private var alpha:Float;
-   /** @private */ private var angle:Float;
-   /** @private */ private var blurX:Float;
-   /** @private */ private var blurY:Float;
-   /** @private */ private var color:Int;
-   /** @private */ private var distance:Float;
-   /** @private */ private var hideObject:Bool;
-   /** @private */ private var inner:Bool;
-   /** @private */ private var knockout:Bool;
-   /** @private */ private var quality:Int;
-   /** @private */ private var strength:Float;
+   public var alpha:Float;
+   public var angle:Float;
+   public var blurX:Float;
+   public var blurY:Float;
+   public var color:Int;
+   public var distance:Float;
+   public var hideObject:Bool;
+   public var inner:Bool;
+   public var knockout:Bool;
+   public var quality:Int;
+   public var strength:Float;
    public function new(in_distance:Float = 4.0, in_angle:Float = 45.0, in_color:Int = 0, in_alpha:Float = 1.0, in_blurX:Float = 4.0, in_blurY:Float = 4.0, in_strength:Float = 1.0, in_quality:Int = 1, in_inner:Bool = false, in_knockout:Bool = false, in_hideObject:Bool = false) 
    {
       super("DropShadowFilter");


### PR DESCRIPTION
I'm not sure what's was the reason for keeping them private,  since they are writeable and public in Flash API.
I've read the nme implementation and tested the changes and filters behave correctly (new effects are only applied when `.filters` is re-assigned) same as in Flash.
