### PR TITLE
Fix for backspace and delete text input

### DIFF
--- a/project/src/common/TextField.cpp
+++ b/project/src/common/TextField.cpp
@@ -638,8 +638,8 @@ void TextField::OnKey(Event &inEvent)
                DeleteChars(caretIndex-1,caretIndex);
                caretIndex--;
             }
-            else if (mCharGroups.size())
-               DeleteChars(0,1);
+            else return;//if (mCharGroups.size())
+               //DeleteChars(0,1);
             ShowCaret();
             OnChange();
             return;
@@ -652,7 +652,8 @@ void TextField::OnKey(Event &inEvent)
             else if (caretIndex<getLength())
             {
                DeleteChars(caretIndex,caretIndex+1);
-            }
+            } else 
+               return;
             mCaretDirty = true;
             ShowCaret();
             OnChange();


### PR DESCRIPTION
Backspace can delete character from the right of 0 cursor position. Unexpected behavior. 
Delete from cursor at the end of text triggers onchange event. Text didn't change and event isn't necessary.   
Trying make it consistent with flash text field.