### PR TITLE
Stack overflow suggested fix for keyboard issue 275

### DIFF
--- a/templates/android/PROJ/src/org/haxe/nme/GameActivity.java
+++ b/templates/android/PROJ/src/org/haxe/nme/GameActivity.java
@@ -975,8 +975,8 @@ implements SensorEventListener
    
    public static void showKeyboard(boolean show)
    {
-      InputMethodManager mgr = (InputMethodManager)mContext.getSystemService(Context.INPUT_METHOD_SERVICE);
-      mgr.hideSoftInputFromWindow(activity.mView.getWindowToken(), 0);
+      InputMethodManager mgr = (InputMethodManager)mContext.getApplicationContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+      mgr.hideSoftInputFromWindow(mContext.getWindow().getDecorView().getWindowToken(), 0);
       
       if (show)
       {


### PR DESCRIPTION
Fix for https://github.com/haxenme/nme/issues/275.

The only thing that could possibly show the keyboard in Pakka Pets is a password confirmation for IAP or credit card info for IAP which is handled through Google keyboard UI. I tested this, it worked fine. The fix is from this post http://stackoverflow.com/questions/10942152/giving-null-pointer-when-using-inputmethodmanager-imm-inputmethodmanagergets.  This is a shot in the dark, but probably a decent one.