### PR TITLE
Fix OpenAL sound resuming

### DIFF
--- a/project/src/audio/OpenALSound.cpp
+++ b/project/src/audio/OpenALSound.cpp
@@ -162,23 +162,12 @@ public:
    void suspend()
    {
       suspended = true;
-      if (playing())
-      {
-         alSourcePause(sourceId);
-         check("pause for suspend");
-         return;
-      }
    }
    
    
    void resume()
    {
-      if (shouldPlay)
-      {
-         alSourcePlay(sourceId);
-         check("resume");
-         suspended = false;
-      }
+      suspended = false;
    }
   
    
@@ -957,7 +946,7 @@ void ResumeOpenAl()
       return;
    
    alcMakeContextCurrent(sgContext);
-
+   alcProcessContext(sgContext);
 }
 
 void PingOpenAl()


### PR DESCRIPTION
I've made some changes which seemingly fixes #338. I'm absolutely unfamiliar with OpenAL, but it appears that the issue was that on suspend and resume we were looping through the ChannelList (which also contained our old non-GC'd channels) and calling resume on them which was in turn playing them regardless if they were complete or not. 

Given that Sound calls SuspendOpenAl() and ResumeOpenAl() anyway, it seemed to me that the contents of the OpenALSourceChannel suspend() and resume() may be pretty redundant if OpenAL was resumed using alcProcessContext. 

This works well at this end, but obviously I'd recommend you sanity check my reasoning!