### PR TITLE
Remove debug spam when a missing asset is encountered

### DIFF
--- a/nme/Assets.hx
+++ b/nme/Assets.hx
@@ -145,9 +145,6 @@ class Assets
    public static function noId(id:String, type:String)
    {
       trace("[nme.Assets] missing asset '" + id + "' of type " + type);
-      for(key in info.keys())
-         trace(" " + key + " -> " + info.get(key).path );
-      trace("---");
    }
 
    public static function badType(id:String, type:String)


### PR DESCRIPTION
When a missing asset is encountered, Assets.hx currently prints out a list of all the assets in the project. If you have a lot of assets this is *really* unhelpful because it obscures the actual missing asset error.