### PR TITLE
Explicitly stop() OpenALBufferChannel when complete

### DIFF
--- a/project/src/audio/OpenALSound.cpp
+++ b/project/src/audio/OpenALSound.cpp
@@ -275,7 +275,7 @@ public:
          alSourcePlay(sourceId);
          if (seekBytes && seekBytes<byteSize)
             alSourcef(sourceId, AL_BYTE_OFFSET, seekBytes);
-         clAddChannel(this, loops!=0);
+         clAddChannel(this, true);
       }
    }
 
@@ -293,12 +293,19 @@ public:
 
    void asyncUpdate()
    {
-      if (!playing() && loops!=0)
+      if (!playing())
       {
-         alSourcef(sourceId, AL_BYTE_OFFSET, 0);
-         alSourcePlay(sourceId);
-         if (loops>0)
-            loops--;
+         if (loops!=0) 
+         {
+            alSourcef(sourceId, AL_BYTE_OFFSET, 0);
+            alSourcePlay(sourceId);
+            if (loops>0) 
+               loops--;
+         }
+         else 
+         {
+            stop();
+         }
       }
    }
 


### PR DESCRIPTION
In #342 I mentioned that `OpenALBufferChannel`s remained in the channel list even when they were long completed (albeit the garbage collector did seem to eventually take care of them), but in our game it turned out that this list could get to be _very_ big indeed. 

I took a little time out today to have a look at the code and determined (as you suggested) that `stop()` was never hit and so `clRemoveChannel` wasn't called as a result. To fix this I flagged all buffer channels async (previously only looping ones were) so that `asyncUpdate()` was always run and from there called `stop()` at the appropriate time. 

The only thing I was concerned about was that `stop()` is called in the destructor too, so I worried that the double call might mess something up, but everything _looks_ pretty guarded in there from what I can see. Beyond that, this doesn't look to have significant overhead (especially given that the channel list would typically be massively shorter as a result during normal runtime), but there's obviously every chance I've misunderstood something. 
