### PR TITLE
Convert TextFormatAlign to enum abstract.

### DIFF
--- a/nme/text/TextFormatAlign.hx
+++ b/nme/text/TextFormatAlign.hx
@@ -1,13 +1,13 @@
 package nme.text;
 #if (!flash)
 
-@:nativeProperty
-class TextFormatAlign 
+@:enum
+abstract TextFormatAlign(String) from String to String
 {
-   public static inline var LEFT = "left";
-   public static inline var RIGHT = "right";
-   public static inline var CENTER = "center";
-   public static inline var JUSTIFY = "justify";
+   var LEFT = "left";
+   var RIGHT = "right";
+   var CENTER = "center";
+   var JUSTIFY = "justify";
 }
 
 #else


### PR DESCRIPTION
Probably doesn't make much difference, but changing for OpenFL compatibility. In OpenFL you can have variables of type TextFormatAlign with values such as `TextFormat.LEFT`. This doesn't work with NME since TextFormatAlign is a class but its members are strings.
