### PR TITLE
Audio regression and prior issue fixes

### DIFF
--- a/project/src/audio/ChannelList.cpp
+++ b/project/src/audio/ChannelList.cpp
@@ -197,7 +197,10 @@ void clResumeAllChannels()
       return;
    clLock();
    for(int i = 0; i < sgOpenChannels.size(); i++)
-      sgOpenChannels[i].channel->resume();
+   {
+      if(!sgOpenChannels[i].channel->isComplete())
+         sgOpenChannels[i].channel->resume();
+   }
    clSoundSuspended = false;
    clPingLocked();
    clUnlock();

--- a/project/src/audio/OpenALSound.cpp
+++ b/project/src/audio/OpenALSound.cpp
@@ -162,12 +162,23 @@ public:
    void suspend()
    {
       suspended = true;
+      if (playing())
+      {
+         alSourcePause(sourceId);
+         check("pause for suspend");
+         return;
+      }
    }
    
    
    void resume()
    {
-      suspended = false;
+      if (shouldPlay)
+      {
+         alSourcePlay(sourceId);
+         check("resume");
+         suspended = false;
+      }
    }
   
    
@@ -946,7 +957,7 @@ void ResumeOpenAl()
       return;
    
    alcMakeContextCurrent(sgContext);
-   alcProcessContext(sgContext);
+
 }
 
 void PingOpenAl()


### PR DESCRIPTION
The first commit reverts https://github.com/haxenme/nme/commit/534cdd692749d6557a08e215da071249a076b3b6 which causes this regression https://github.com/haxenme/nme/issues/403.

The 2nd commit fixes the issue the first was trying to tackle. If you play a bunch of single sound effects and then minimize and reopen the app on iOS the code in ChannelList will replay sounds already finished.