### PR TITLE
flag for avoid adding V4Compat

### DIFF
--- a/tools/nme/src/platforms/AndroidPlatform.hx
+++ b/tools/nme/src/platforms/AndroidPlatform.hx
@@ -164,7 +164,10 @@ class AndroidPlatform extends Platform
       {
          var lib = project.dependencies.get(k);
          if (lib.isAndroidProject() && getAndroidProject(lib)!=extensionApi)
-            context.ANDROID_LIBRARY_PROJECTS.push( {index:idx++, path:getAndroidProject(lib)} );
+         {
+            var proj = getAndroidProject(lib);
+            context.ANDROID_LIBRARY_PROJECTS.push( {index:idx++, path:proj} );
+         }
       }
    }
 
@@ -395,6 +398,7 @@ class AndroidPlatform extends Platform
       }
 
       //if (project.androidConfig.minApiLevel < 14)
+      if (project.androidConfig.addV4Compat)
          addV4CompatLib(jarDir);
 
       for(k in project.dependencies.keys())

--- a/tools/nme/src/project/NMEProject.hx
+++ b/tools/nme/src/project/NMEProject.hx
@@ -10,6 +10,7 @@ class AndroidConfig
 {
    public var installLocation:String;
    public var minApiLevel:Int;
+   public var addV4Compat:Bool;
    public var targetApiLevel:Null<Int>;
    public var buildApiLevel:Null<Int>;
    public var appHeader:Array<String>;
@@ -28,6 +29,7 @@ class AndroidConfig
    {
       installLocation = "preferExternal";
       minApiLevel = 14;
+      addV4Compat = true;
       appHeader = [];
       appIntent = [];
       appActivity = [];

--- a/tools/nme/src/project/NMMLParser.hx
+++ b/tools/nme/src/project/NMMLParser.hx
@@ -469,7 +469,9 @@ class NMMLParser
       if (element.has.extension)
          project.androidConfig.extensions.set(substitute(element.att.extension),true);
 
-
+      if (element.has.addV4Compat)
+         project.androidConfig.addV4Compat = element.att.addV4Compat!="false";
+ 
       for(childElement in element.elements) 
       {
          if (isValidElement(childElement, ""))


### PR DESCRIPTION
Use
`<android addV4Compat="false"/>`
in xml when you want to add your own V4Compat lib. 
addV4Compat is true by default.

Also, added a temporary variable for getAndroidProject (AndroidPlatform.hx line 167) to avoid crash on
my current haxe/hxcpp version, which should have the same behavior but
safer.

Thanks