### PR TITLE
fix addV4Compat flag

### DIFF
--- a/tools/nme/src/project/NMMLParser.hx
+++ b/tools/nme/src/project/NMMLParser.hx
@@ -470,7 +470,7 @@ class NMMLParser
          project.androidConfig.extensions.set(substitute(element.att.extension),true);
 
       if (element.has.addV4Compat)
-         project.androidConfig.addV4Compat = !parseBool(element.att.addV4Compat);
+         project.androidConfig.addV4Compat = parseBool(element.att.addV4Compat);
  
       for(childElement in element.elements) 
       {


### PR DESCRIPTION
The flag does not need "!" since it matches the internal addV4Flag. Thanks.