### PR TITLE
BC7 textures for Windows / Initial compressed texture support

### DIFF
--- a/include/nme/Pixel.h
+++ b/include/nme/Pixel.h
@@ -19,6 +19,9 @@ enum PixelFormat
    pfHardware     = 0x10,
    pfARGB4444     = 0x11,
    pfRGB565       = 0x12,
+#ifdef HX_WINDOWS
+   pfDDS          = 0x20,
+#endif
    
    pfHasAlpha     = 0x01,
 };

--- a/nme/display/LoaderInfo.hx
+++ b/nme/display/LoaderInfo.hx
@@ -67,6 +67,7 @@ class LoaderInfo extends URLLoader
          case "jpg","jpeg": "image/jpeg";
          case "png": "image/png";
          case "gif": "image/gif";
+         case "DDS": "image/DDS";
          default:
             throw "Unrecognized file " + pendingURL;
       }

--- a/nme/display/LoaderInfo.hx
+++ b/nme/display/LoaderInfo.hx
@@ -67,7 +67,7 @@ class LoaderInfo extends URLLoader
          case "jpg","jpeg": "image/jpeg";
          case "png": "image/png";
          case "gif": "image/gif";
-         case "DDS": "image/DDS";
+         case "dds": "image/dds";
          default:
             throw "Unrecognized file " + pendingURL;
       }

--- a/project/include/Surface.h
+++ b/project/include/Surface.h
@@ -119,7 +119,9 @@ class SimpleSurface : public Surface
 {
 public:
    SimpleSurface(int inWidth,int inHeight,PixelFormat inPixelFormat,int inByteAlign=4,int inGPUPixelFormat=-1);
-
+#ifdef HX_WINDOWS
+   SimpleSurface(int inWidth,int inHeight,PixelFormat inPixelFormat,int inByteAlign,int inGPUPixelFormat, unsigned char* data, size_t texture, int size);
+#endif
    PixelFormat Format() const  { return mPixelFormat; }
 
    int Width() const  { return mWidth; }

--- a/project/include/Surface.h
+++ b/project/include/Surface.h
@@ -118,10 +118,8 @@ public:
 class SimpleSurface : public Surface
 {
 public:
-   SimpleSurface(int inWidth,int inHeight,PixelFormat inPixelFormat,int inByteAlign=4,int inGPUPixelFormat=-1);
-#ifdef HX_WINDOWS
-   SimpleSurface(int inWidth,int inHeight,PixelFormat inPixelFormat,int inByteAlign,int inGPUPixelFormat, unsigned char* data, size_t texture, int size);
-#endif
+   SimpleSurface(int inWidth,int inHeight,PixelFormat inPixelFormat,int inByteAlign=4,int inGPUPixelFormat=-1,uint8* inData=NULL);
+
    PixelFormat Format() const  { return mPixelFormat; }
 
    int Width() const  { return mWidth; }

--- a/project/src/common/Surface.cpp
+++ b/project/src/common/Surface.cpp
@@ -83,10 +83,10 @@ SimpleSurface::SimpleSurface(int inWidth,int inHeight,PixelFormat inPixelFormat,
       mBase = 0;
       if (inGPUFormat!=0)
          mGPUPixelFormat = inGPUFormat;
-#if defined(HX_WINDOWS) || defined(NME_KTX) || defined(SWT_GNF)
+#if defined(HX_WINDOWS)
       if(inData!=NULL)
       {
-	     //create now?
+         //create now?
          mBase = inData;
          createHardwareSurface();
          //delete [] mBase; <-- crash here

--- a/project/src/common/Surface.cpp
+++ b/project/src/common/Surface.cpp
@@ -47,7 +47,7 @@ Texture *Surface::GetTexture(HardwareContext *inHardware,int inPlane)
 
 // --- SimpleSurface -------------------------------------------------------
 
-SimpleSurface::SimpleSurface(int inWidth,int inHeight,PixelFormat inPixelFormat,int inByteAlign,int inGPUFormat)
+SimpleSurface::SimpleSurface(int inWidth,int inHeight,PixelFormat inPixelFormat,int inByteAlign,int inGPUFormat, uint8* inData)
 {
    mWidth = inWidth;
    mHeight = inHeight;
@@ -83,39 +83,15 @@ SimpleSurface::SimpleSurface(int inWidth,int inHeight,PixelFormat inPixelFormat,
       mBase = 0;
       if (inGPUFormat!=0)
          mGPUPixelFormat = inGPUFormat;
-
+#if defined(HX_WINDOWS) || defined(NME_KTX) || defined(SWT_GNF)
+      if(inData!=NULL)
+      {
+      }
+      else
+#endif
       createHardwareSurface();
    }
 }
-
-#ifdef HX_WINDOWS
-//Constructor For compressed textures
-SimpleSurface::SimpleSurface(int inWidth,int inHeight,PixelFormat inPixelFormat,int inByteAlign,int inGPUFormat, unsigned char* data, size_t texture, int size)
-{
-   mWidth = inWidth;
-   mHeight = inHeight;
-   mTexture = 0;
-   mPixelFormat = inPixelFormat;
-   mGPUPixelFormat = inPixelFormat;
-   
-   // Default to using premultiplied alpha
-   #ifndef NME_NOPREMULTIPLIED_ALPHA
-   if (mPixelFormat != pfAlpha)
-      mFlags |= surfUsePremultipliedAlpha;
-   #endif
-
-   if (inGPUFormat!=-1)
-   {
-      mStride = size;
-      mBase = data;
-
-      if (inGPUFormat!=0)
-         mGPUPixelFormat = inGPUFormat;
-
-      //createHardwareSurface();
-   }
-}
-#endif
 
 SimpleSurface::~SimpleSurface()
 {

--- a/project/src/common/Surface.cpp
+++ b/project/src/common/Surface.cpp
@@ -86,6 +86,12 @@ SimpleSurface::SimpleSurface(int inWidth,int inHeight,PixelFormat inPixelFormat,
 #if defined(HX_WINDOWS) || defined(NME_KTX) || defined(SWT_GNF)
       if(inData!=NULL)
       {
+	     //create now?
+         mBase = inData;
+         createHardwareSurface();
+         //delete [] mBase; <-- crash here
+         free(mBase);
+         mBase = NULL;
       }
       else
 #endif

--- a/project/src/common/Surface.cpp
+++ b/project/src/common/Surface.cpp
@@ -88,6 +88,35 @@ SimpleSurface::SimpleSurface(int inWidth,int inHeight,PixelFormat inPixelFormat,
    }
 }
 
+#ifdef HX_WINDOWS
+//Constructor For compressed textures
+SimpleSurface::SimpleSurface(int inWidth,int inHeight,PixelFormat inPixelFormat,int inByteAlign,int inGPUFormat, unsigned char* data, size_t texture, int size)
+{
+   mWidth = inWidth;
+   mHeight = inHeight;
+   mTexture = 0;
+   mPixelFormat = inPixelFormat;
+   mGPUPixelFormat = inPixelFormat;
+   
+   // Default to using premultiplied alpha
+   #ifndef NME_NOPREMULTIPLIED_ALPHA
+   if (mPixelFormat != pfAlpha)
+      mFlags |= surfUsePremultipliedAlpha;
+   #endif
+
+   if (inGPUFormat!=-1)
+   {
+      mStride = size;
+      mBase = data;
+
+      if (inGPUFormat!=0)
+         mGPUPixelFormat = inGPUFormat;
+
+      //createHardwareSurface();
+   }
+}
+#endif
+
 SimpleSurface::~SimpleSurface()
 {
    if (mBase)

--- a/project/src/opengl/OGLTexture.cpp
+++ b/project/src/opengl/OGLTexture.cpp
@@ -171,6 +171,30 @@ public:
       mDirtyRect = Rect(0,0);
       mContextVersion = gTextureContextVersion;
 
+#ifdef HX_WINDOWS
+      if( pfDDS == mSurface->GPUFormat())
+      {
+           mTextureWidth = mPixelWidth;
+           mTextureHeight = mPixelHeight;
+           mTextureID = 0;
+           glGenTextures(1, &mTextureID);
+           glBindTexture(GL_TEXTURE_2D,mTextureID);
+           mRepeat = mCanRepeat;
+           mSmooth = true;
+           uint8 * buffer = (uint8 *)mSurface->Row(0);
+           static int level = 0; //no mipmaps
+           static int nBlockSize = 16; //8 if DXT1
+           int size = ((mPixelWidth+3)/4) * ((mPixelHeight+3)/4) * nBlockSize;
+           glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, mRepeat ? GL_REPEAT : GL_CLAMP_TO_EDGE );
+           glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, mRepeat ? GL_REPEAT : GL_CLAMP_TO_EDGE );
+           glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+           glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+           glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0 );
+           glCompressedTexImage2D(GL_TEXTURE_2D, level,  GL_COMPRESSED_RGBA_BPTC_UNORM_ARB /*GL_COMPRESSED_RGBA_S3TC_DXT5_EXT*/, mPixelWidth, mPixelHeight,0, size, buffer);
+            return;
+      }
+#endif
+
       bool non_po2 = NonPO2Supported(inFlags & surfNotRepeatIfNonPO2);
       //printf("Using non-power-of-2 texture %d\n",non_po2);
 

--- a/project/src/opengl/OGLTexture.cpp
+++ b/project/src/opengl/OGLTexture.cpp
@@ -258,7 +258,6 @@ public:
               internalformat = GL_COMPRESSED_RGBA_S3TC_DXT5_EXT;
          }
 
-        fprintf(stderr, "DDS mips:%d size:%d(%d) pitchOrLinearSize:%d dx10:%s(0x%x).\n", header->mipMapCount, level, size, header->pitchOrLinearSize, bDX10Header?"TRUE":"FALSE", header->ddspf.fourCC);
          glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, mRepeat ? GL_REPEAT : GL_CLAMP_TO_EDGE );
          glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, mRepeat ? GL_REPEAT : GL_CLAMP_TO_EDGE );
          glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);

--- a/tools/nme/src/project/Asset.hx
+++ b/tools/nme/src/project/Asset.hx
@@ -50,7 +50,7 @@ class Asset
 
          switch(extension.toLowerCase()) 
          {
-            case "jpg", "jpeg", "png", "gif":
+            case "jpg", "jpeg", "png", "gif", "dds":
                type = AssetType.IMAGE;
 
             case "otf", "ttf":

--- a/tools/nme/src/project/NMMLParser.hx
+++ b/tools/nme/src/project/NMMLParser.hx
@@ -344,7 +344,7 @@ class NMMLParser
                   switch(type) 
                   {
                      case IMAGE:
-                        include = "*.jpg|*.jpeg|*.png|*.gif";
+                        include = "*.jpg|*.jpeg|*.png|*.gif|*.dds";
 
                      case SOUND:
                         include = "*.wav|*.ogg";


### PR DESCRIPTION
Hopefully PVRTC2, ETC2(KTX) and others for mobile can follow.

This commit should not affect current behavior but it may require a
fallback for detecting non-supported hardware, or prevent texture modification.

You can use Texconv
https://github.com/Microsoft/DirectXTex/releases/tag/oct2016
( https://github.com/Microsoft/DirectXTex/tree/master/Texconv )
to convert your png to dds.
"texconv.exe" -pmalpha  -f BC7_UNORM -o out_dir in.png -m 1

Can be later tweaked to support DXT4(BC3) textures (useful for "non-cartoony"
textures) as well. It could add mipmap support as well.

You can test it with DisplayingABitmap sample.
We appreciate your comments.