### PR TITLE
Android: add warning for DLC in JNI onCallback

### DIFF
--- a/nme/JNI.hx
+++ b/nme/JNI.hx
@@ -32,7 +32,8 @@ class JNI
       if (field != null)
          return Reflect.callMethod(inObj, field, inArgs);
 
-      trace("onCallback - unknown field " + inFunc);
+      trace("onCallback - unknown field " + inFunc + " in " + inObj);
+      trace("Make sure to use '@:keep' if enabling DLC");
 
       return null;
    }


### PR DESCRIPTION
 add warning to use "keep" in functuns for onCallback