### PR TITLE
Fix windows icon padding and alpha

### DIFF
--- a/tools/nme/src/helpers/IconHelper.hx
+++ b/tools/nme/src/helpers/IconHelper.hx
@@ -200,7 +200,7 @@ class IconHelper
          ico.writeInt(0); // cols
          ico.writeInt(0); // important
 
-         var bits = bmp.getPixels(new Rectangle(0, 0, size, size));
+         var bits = BitmapData.getRGBAPixels(bmp);
          var and_mask = new ByteArray();
 
          for(y in 0...size) 
@@ -211,16 +211,16 @@ class IconHelper
 
             for(i in 0...size) 
             {
-               var a = bits.readByte();
                var r = bits.readByte();
                var g = bits.readByte();
                var b = bits.readByte();
+               var a = bits.readByte();
                ico.writeByte(b);
                ico.writeByte(g);
                ico.writeByte(r);
                ico.writeByte(a);
 
-               if (a < 128)
+               if (a == 0)
                   mask |= bit;
 
                bit = bit >> 1;

--- a/tools/nme/src/helpers/IconHelper.hx
+++ b/tools/nme/src/helpers/IconHelper.hx
@@ -215,12 +215,13 @@ class IconHelper
                var g = bits.readByte();
                var b = bits.readByte();
                var a = bits.readByte();
+
                ico.writeByte(b);
                ico.writeByte(g);
                ico.writeByte(r);
                ico.writeByte(a);
 
-               if (a == 0)
+               if ((a&0x80) == 0)
                   mask |= bit;
 
                bit = bit >> 1;

--- a/tools/nme/src/helpers/IconHelper.hx
+++ b/tools/nme/src/helpers/IconHelper.hx
@@ -137,7 +137,6 @@ class IconHelper
    public static function createWindowsIcon(icons:Array<Icon>, targetPath:String):Bool 
    {
       var sizes = [ 16, 24, 32, 40, 48, 64, 96, 128, 256 ];
-      var paddingTotal:Array<Int> = [];
       var paddingPerRow:Array<Int> = [];
       var bmps = new Array<BitmapData>();
 
@@ -151,9 +150,9 @@ class IconHelper
          {
             bmps.push(bmp);
             data_pos += 16;
+            var paddPerRow:Int = Std.int(((32-size%32)%32)/8);
+            paddingPerRow.push(paddPerRow);
          }
-         var paddPerRow:Int = Std.int(((32-size%32)%32)/8);
-         paddingPerRow.push(paddPerRow);
       }
 
       var ico = new ByteArray();
@@ -184,8 +183,8 @@ class IconHelper
       for(bmp in bmps) 
       {
          var size:Int = bmp.width;
-         var rowPadding:Int = paddingPerRow[j++];
-         var extraPadding:Int = rowPadding * size;
+         var paddPerRow:Int = paddingPerRow[j++];
+         var extraPadding:Int = paddPerRow * size;
          var xor_size = size * size * 4;
          var and_size = size * size >> 3;
 
@@ -233,7 +232,7 @@ class IconHelper
                   mask = 0;
                }
             }
-            for(k in 0...rowPadding)
+            for(k in 0...paddPerRow)
                and_mask.writeByte(0);
          }
          ico.writeBytes(and_mask, 0, and_mask.length);


### PR DESCRIPTION
The rows of ADD masks needs to be aligned to 4 bytes. 

Todo: there is still an issue when alpha bits not set correctly.  Seem an issue with BitmapData.load
Edit. It works OK now.

You can check the generated icons with "Icon Browser" https://www.codeproject.com/kb/cs/iconlib.aspx
