### PR TITLE
[windows sdl2] adjust small icon size

### DIFF
--- a/project/src/sdl2/SDL2Stage.cpp
+++ b/project/src/sdl2/SDL2Stage.cpp
@@ -1575,8 +1575,11 @@ void CreateMainFrame(FrameCreationCallback inOnFrame, int inWidth, int inHeight,
       
       #ifdef HX_WINDOWS
       HINSTANCE handle = ::GetModuleHandle(0);
-      LPARAM icon = (LPARAM)::LoadImage(handle, MAKEINTRESOURCE(101), IMAGE_ICON, 
+      LPSTR resource = MAKEINTRESOURCE(101);
+      LPARAM icon = (LPARAM)::LoadImage(handle, resource, IMAGE_ICON, 
          GetSystemMetrics(SM_CXICON), GetSystemMetrics(SM_CYICON), 0);
+      LPARAM smicon = (LPARAM)::LoadImage(handle, resource, IMAGE_ICON, 
+         GetSystemMetrics(SM_CXSMICON), GetSystemMetrics(SM_CYSMICON), 0);
       
       if (icon)
       {
@@ -1586,7 +1589,10 @@ void CreateMainFrame(FrameCreationCallback inOnFrame, int inWidth, int inHeight,
          {
             HWND hwnd = wminfo.info.win.window;
             ::SendMessage(hwnd, WM_SETICON, ICON_BIG, icon);
-            ::SendMessage(hwnd, WM_SETICON, ICON_SMALL, icon);
+            if(smicon)
+                ::SendMessage(hwnd, WM_SETICON, ICON_SMALL, smicon);
+            else
+                ::SendMessage(hwnd, WM_SETICON, ICON_SMALL, icon);
          }
       }
       #endif


### PR DESCRIPTION
Use the 16x16 icon on top of the window and taskbar (small icons option on Windows 10), instead of the one of 32x32.  
Related: 
https://blog.barthe.ph/2009/07/17/wmseticon/
http://www.openfl.org/archive/community/bugs/lack-of-16x16-windows-toolbar-icon/