### PR TITLE
Complete cache clean in destructor

### DIFF
--- a/project/src/common/Display.cpp
+++ b/project/src/common/Display.cpp
@@ -60,6 +60,7 @@ DisplayObject::~DisplayObject()
       mGfx->DecRef();
    }
    delete mBitmapCache;
+   mBitmapCache = 0;
    if (mMask)
       setMask(0);
    ClearFilters();


### PR DESCRIPTION
I have strange cases some time when DisplayObject destructor called twice and if I have casheAsBitmap = true, app crash in BitmapCache class here:

BitmapCache::~BitmapCache()
{
   mBitmap->DecRef(); // crash here DecRef when its already 0
}