### PR TITLE
hxtelemetry: fix timing names

### DIFF
--- a/src/nme/app/Window.hx
+++ b/src/nme/app/Window.hx
@@ -120,9 +120,9 @@ class Window
       if (appEventHandler==null)
           return;
 
-#if HXCPP_TELEMETRY
-      Stage.hxt.start_timing ("EVENT");
-#end
+      #if HXCPP_TELEMETRY
+      Stage.hxt.start_timing (".event");
+      #end
       var event:AppEvent = inEvent;
       try
       {
@@ -269,9 +269,9 @@ class Window
          event.pollTime = 0;
          appEventHandler.onUnhandledException(e,stack);
       }
-#if HXCPP_TELEMETRY
-      Stage.hxt.end_timing ("EVENT");
-#end
+      #if HXCPP_TELEMETRY
+      Stage.hxt.end_timing (".event");
+      #end
    }
 
    public function beginRender()

--- a/src/nme/display/Stage.hx
+++ b/src/nme/display/Stage.hx
@@ -149,7 +149,16 @@ class Stage extends DisplayObjectContainer implements nme.app.IPollClient implem
    public function new(inWindow:Window)
    {
       #if HXCPP_TELEMETRY
-      hxt = new HxTelemetry();
+
+      var config = new Config();
+      config.allocations = true;
+      config.host = 'localhost';
+      config.app_name = 'NME';
+      config.activity_descriptors = [ 
+          { name: '.event', description: "Event", color: 0xB6B6D5},
+          { name: '.render', description: "Rendering", color:0x91D891},
+      ];
+      hxt = new HxTelemetry(config);
       #end
 
       nmeEnterFrameEvent = new Event(Event.ENTER_FRAME);

--- a/src/nme/display/Stage.hx
+++ b/src/nme/display/Stage.hx
@@ -142,15 +142,16 @@ class Stage extends DisplayObjectContainer implements nme.app.IPollClient implem
    var nmeFrameMemIndex:Int;
    #end
 
-#if HXCPP_TELEMETRY
+   #if HXCPP_TELEMETRY
    public static var hxt:HxTelemetry;
-#end
+   #end
 
    public function new(inWindow:Window)
    {
-#if HXCPP_TELEMETRY
+      #if HXCPP_TELEMETRY
       hxt = new HxTelemetry();
-#end
+      #end
+
       nmeEnterFrameEvent = new Event(Event.ENTER_FRAME);
       nmeRenderEvent = new Event(Event.RENDER);
 
@@ -514,9 +515,10 @@ class Stage extends DisplayObjectContainer implements nme.app.IPollClient implem
 
    public function onRender(inFrameDue:Bool)
    {
-#if HXCPP_TELEMETRY
+      #if HXCPP_TELEMETRY
       hxt.advance_frame();
-#end
+      #end
+
       if (inFrameDue)
          nmeBroadcast(nmeEnterFrameEvent);
 
@@ -580,7 +582,15 @@ class Stage extends DisplayObjectContainer implements nme.app.IPollClient implem
             nme_set_render_gc_free(true);
             Gc.enterGCFreeZone();
             nmeCollectionLock.release();
+            #if HXCPP_TELEMETRY
+            var stack:String = hxt.unwind_stack();
+            hxt.start_timing (".render");
+            #end
             nme_render_stage(nmeHandle);
+            #if HXCPP_TELEMETRY
+            hxt.end_timing (".render");
+            hxt.rewind_stack (stack);
+            #end
             Gc.exitGCFreeZone();
             nme_set_render_gc_free(false);
          }
@@ -592,15 +602,15 @@ class Stage extends DisplayObjectContainer implements nme.app.IPollClient implem
       if (!rendered)
       #end
       {
-#if HXCPP_TELEMETRY
+         #if HXCPP_TELEMETRY
          var stack:String = hxt.unwind_stack();
-         hxt.start_timing ("RENDER");
-#end
+         hxt.start_timing (".render");
+         #end
          nme_render_stage(nmeHandle);
-#if HXCPP_TELEMETRY
-         hxt.end_timing ("RENDER");
+         #if HXCPP_TELEMETRY
+         hxt.end_timing (".render");
          hxt.rewind_stack (stack);
-#end
+         #end
       }
    }
 


### PR DESCRIPTION
Now "render" and "event" names show correctly on hxScout.  Fix code
indentation.
Issue: https://github.com/haxenme/nme/issues/451