### PR TITLE
hxTelemetry parameters from xml

### DIFF
--- a/include.nmml
+++ b/include.nmml
@@ -17,7 +17,7 @@
 
 <set name="preloader" value="${NME}/ndll/Emscripten/preloader.js" if="std-preloader"/>
 
-<section if="NME_HXTELEMETRY">
+<section if="NME_HXTELEMETRY || telemetry">
    <haxelib name="hxtelemetry"/>
    <haxedef name="HXCPP_TELEMETRY"/>
    <haxedef name="HXCPP_STACK_TRACE"/>

--- a/src/nme/app/Application.hx
+++ b/src/nme/app/Application.hx
@@ -12,6 +12,10 @@ import cpp.vm.Mutex;
 import neko.vm.Mutex;
 #end
 
+#if HXCPP_TELEMETRY
+import hxtelemetry.HxTelemetry;
+#end
+
 typedef WindowParams = {
     ? flags        : Null<Int>,
     ? fps          : Null<Float>,
@@ -62,6 +66,7 @@ class Application
    public static var packageName(default, null):String;
    public static var file(default, null):String;
 
+
    public static var build(get, null):String;
    public static var ndllVersion(get, null):Int;
    public static var nmeStateVersion(get, null):String;
@@ -76,7 +81,11 @@ class Application
    static var mainThreadJobMutex = new Mutex();
    #end
 
-
+   #if HXCPP_TELEMETRY
+   public static var hxt:HxTelemetry;
+   public static var telemetryHost(default, null):String = "localhost";
+   public static var telemetryAllocations:Bool = true;
+   #end
 
    public static function createWindow(inOnLoaded:Window->Void, inParams:WindowParams)
    {
@@ -256,6 +265,39 @@ class Application
 
       nme_set_package(inCompany, inFile, inPack, inVersion);
    }
+
+   #if HXCPP_TELEMETRY
+   public static function initHxTelemetry() 
+   {
+      if (hxt==null)
+      {
+         var config = new Config();
+         config.allocations = Application.telemetryAllocations;
+         config.host = Application.telemetryHost;
+         config.app_name = Application.file;
+         //trace("telemetry config[ allocations:"+(config.allocations?"t":"f")+", host:"+config.host+", app_name:"+config.app_name);
+         config.activity_descriptors = [
+             { name: '.event', description: "Event", color: 0xB6B6D5},
+             { name: '.render', description: "Rendering", color:0x91D891},
+         ];
+         hxt = new HxTelemetry(config);
+      }
+   }
+
+   public static inline function getHxTelemetry():HxTelemetry
+   {
+      return hxt;
+   }
+
+   public static function setTelemetryConfigHost(inTelemetryHost:String) 
+   {
+      telemetryHost = inTelemetryHost;
+   }
+   public static function setTelemetryConfigAllocations(inTelemetryAllocations:Bool) 
+   {
+      telemetryAllocations = inTelemetryAllocations;
+   }
+   #end
    
    public static function get_build():String { return Version.name; }
    public static function get_ndllVersion():Int { return nme_get_ndll_version(); }

--- a/src/nme/app/Window.hx
+++ b/src/nme/app/Window.hx
@@ -121,7 +121,9 @@ class Window
           return;
 
       #if HXCPP_TELEMETRY
-      Stage.hxt.start_timing (".event");
+      var hxt = Application.getHxTelemetry();
+      var hxtStack:String = hxt.unwind_stack();
+      hxt.start_timing (".event");
       #end
       var event:AppEvent = inEvent;
       try
@@ -270,7 +272,8 @@ class Window
          appEventHandler.onUnhandledException(e,stack);
       }
       #if HXCPP_TELEMETRY
-      Stage.hxt.end_timing (".event");
+      hxt.end_timing (".event");
+      hxt.rewind_stack (hxtStack);
       #end
    }
 

--- a/src/nme/display/Stage.hx
+++ b/src/nme/display/Stage.hx
@@ -38,10 +38,6 @@ import haxe.CallStack;
 import cpp.vm.Gc;
 #end
 
-#if HXCPP_TELEMETRY
-import hxtelemetry.HxTelemetry;
-#end
-
 @:nativeProperty
 class Stage extends DisplayObjectContainer implements nme.app.IPollClient implements nme.app.IAppEventHandler
 {
@@ -142,23 +138,10 @@ class Stage extends DisplayObjectContainer implements nme.app.IPollClient implem
    var nmeFrameMemIndex:Int;
    #end
 
-   #if HXCPP_TELEMETRY
-   public static var hxt:HxTelemetry;
-   #end
-
    public function new(inWindow:Window)
    {
       #if HXCPP_TELEMETRY
-
-      var config = new Config();
-      config.allocations = true;
-      config.host = 'localhost';
-      config.app_name = 'NME';
-      config.activity_descriptors = [ 
-          { name: '.event', description: "Event", color: 0xB6B6D5},
-          { name: '.render', description: "Rendering", color:0x91D891},
-      ];
-      hxt = new HxTelemetry(config);
+      Application.initHxTelemetry();
       #end
 
       nmeEnterFrameEvent = new Event(Event.ENTER_FRAME);
@@ -182,7 +165,7 @@ class Stage extends DisplayObjectContainer implements nme.app.IPollClient implem
       nmeLastRender = 0;
       nmeLastDown = [];
       nmeLastClickTime = 0.0;
-	   nmeTouchInfo = new Map<Int,TouchInfo>();
+      nmeTouchInfo = new Map<Int,TouchInfo>();
       nmeJoyAxisData = new Map<Int,Array<Float>>();
 
       #if stage3d
@@ -199,8 +182,6 @@ class Stage extends DisplayObjectContainer implements nme.app.IPollClient implem
       nmeLastPreempt = false;
       nmeFrameMemIndex = 0;
       #end
-
-
    }
 
    public static dynamic function getOrientation():Int 
@@ -525,6 +506,7 @@ class Stage extends DisplayObjectContainer implements nme.app.IPollClient implem
    public function onRender(inFrameDue:Bool)
    {
       #if HXCPP_TELEMETRY
+      var hxt = Application.getHxTelemetry();
       hxt.advance_frame();
       #end
 

--- a/templates/haxe/ApplicationMain.hx
+++ b/templates/haxe/ApplicationMain.hx
@@ -66,6 +66,14 @@ class ApplicationMain
          ::end::
 
          nme.app.Application.setPackage("::APP_COMPANY::", "::APP_FILE::", "::APP_PACKAGE::", "::APP_VERSION::");
+         #if HXCPP_TELEMETRY
+         ::if TELEMETRY_HOST::
+         nme.app.Application.setTelemetryConfigHost("::TELEMETRY_HOST::");
+         ::end::
+         ::if TELEMETRY_ALOCATIONS::
+         nme.app.Application.setTelemetryConfigAllocations("::TELEMETRY_ALOCATIONS::" != "false");
+         ::end::
+         #end
          nme.text.Font.useNative = ::NATIVE_FONTS::;
 
          nme.AssetData.create();


### PR DESCRIPTION
Get host and allocations parameters from xml and fix app_name.  
Currently host and allocations are set using "setenv" from xml with names TELEMETRY_HOST and TELEMETRY_ALLOCATIONS ( OpenFL uses a config:hxtelemetry tag ). 
Example:
```
	<setenv name="TELEMETRY_HOST" value="localhost"/>
	<setenv name="TELEMETRY_ALLOCATIONS" value="true"/>
```

Moved most of telemetry code from Stage.hx to Application.hx. 

Allow `-Dtelemetry` as in OpenFL, as well -DNME_HXTELEMETRY.  

