### PR TITLE
fix android screen DPI

### DIFF
--- a/templates/android/PROJ/src/org/haxe/nme/GameActivity.java
+++ b/templates/android/PROJ/src/org/haxe/nme/GameActivity.java
@@ -424,7 +424,7 @@ implements SensorEventListener
    
    public static double CapabilitiesGetScreenDPI()
    {
-      return metrics.xdpi;   
+      return metrics.densityDpi;   
    }
    
    


### PR DESCRIPTION
In some cases xdpi and desityDpi the same. On my android tv 7.1.1 I have 240 but this method return me xdpi value 68 and my content looks small.