### PR TITLE
NME_ANGLE: force texture width to an even number

### DIFF
--- a/project/src/opengl/OGLTexture.cpp
+++ b/project/src/opengl/OGLTexture.cpp
@@ -225,7 +225,7 @@ public:
       mCanRepeat = IsPower2(mTextureWidth) && IsPower2(mTextureHeight);
 
       #ifdef NME_ANGLE
-      if (mTextureWidth%2!=0)
+      if (mTextureWidth & 0x1)
          mTextureWidth++;
       #endif
 

--- a/project/src/opengl/OGLTexture.cpp
+++ b/project/src/opengl/OGLTexture.cpp
@@ -224,6 +224,11 @@ public:
       mTextureHeight = non_po2 ? mPixelHeight : UpToPower2(mPixelHeight);
       mCanRepeat = IsPower2(mTextureWidth) && IsPower2(mTextureHeight);
 
+      #ifdef NME_ANGLE
+      if (mTextureWidth%2!=0)
+         mTextureWidth++;
+      #endif
+
       mTextureID = 0;
       glGenTextures(1, &mTextureID);
       CreateTexture();


### PR DESCRIPTION
06-Sound sample has a non-even width texture background that shows incorrectly with` -DNME_ANGLE` (both windows and winrt). Forcing an even number width solved the issue.