### PR TITLE
Increase performance of NME command line tool by switching it to CPP.

### DIFF
--- a/tools/nme/compile.hxml
+++ b/tools/nme/compile.hxml
@@ -1,11 +1,20 @@
--main CommandLineTools
+-cp src
+-main CommandLineToolsLauncher
 -neko ../../nme.n
+-debug
+
+--next
+
+-main CommandLineTools
+-cpp ../../bin/tools
 -cp src
 -cp src/helpers
 -cp src/project
 -cp ../../src
 -D nme
 -D ndll_silent_fail=1
+-D HXCPP_COMPILE_CACHE
+#-D profileNMMLParser
 -lib format
 -lib gm2d
 -lib hxcpp

--- a/tools/nme/src/CommandLineTools.hx
+++ b/tools/nme/src/CommandLineTools.hx
@@ -4,7 +4,6 @@ import std.RealSys;
 import std.SysProxy;
 import haxe.io.Path;
 import sys.io.File;
-import sys.io.Process;
 import sys.FileSystem;
 import platforms.Platform;
 import nme.system.System;
@@ -12,7 +11,6 @@ import nme.Loader;
 import nme.net.SharedObject;
 import nme.script.Client;
 import NMEProject;
-import nme.AlphaMode;
 
 using StringTools;
 

--- a/tools/nme/src/CommandLineToolsLauncher.hx
+++ b/tools/nme/src/CommandLineToolsLauncher.hx
@@ -1,0 +1,16 @@
+package;
+
+class CommandLineToolsLauncher 
+{
+    public static function main():Void {
+        Sys.command('./bin/tools/${calcBinName()}', Sys.args());
+    }
+
+    static function calcBinName():String {
+        #if windows
+        return 'CommandLineTools-debug.exe';
+        #else
+        return 'CommandLineTools-debug';
+        #end
+    }
+}

--- a/tools/nme/src/helpers/FileHelper.hx
+++ b/tools/nme/src/helpers/FileHelper.hx
@@ -7,7 +7,6 @@ import haxe.Template;
 import sys.io.File;
 import sys.io.FileOutput;
 import sys.FileSystem;
-import neko.Lib;
 import platforms.Platform;
 using StringTools;
 

--- a/tools/nme/src/helpers/LogHelper.hx
+++ b/tools/nme/src/helpers/LogHelper.hx
@@ -1,6 +1,10 @@
 package;
 
+#if neko
 import neko.Lib;
+#else
+import cpp.Lib;
+#end
 #if nme
 import nme.Loader;
 #end

--- a/tools/nme/src/platforms/Platform.hx
+++ b/tools/nme/src/platforms/Platform.hx
@@ -5,7 +5,6 @@ import sys.io.File;
 import haxe.io.Path;
 import sys.net.Host;
 import sys.net.Socket;
-import nme.AlphaMode;
 using StringTools;
 
 class Platform

--- a/tools/nme/src/project/NMMLParser.hx
+++ b/tools/nme/src/project/NMMLParser.hx
@@ -1,5 +1,6 @@
 package;
 
+import haxe.io.Error;
 import haxe.io.Path;
 import haxe.xml.Fast;
 import sys.io.File;
@@ -21,8 +22,18 @@ class NMMLParser
 
    public function new(inProject:NMEProject, path:String, inWarnUnknown:Bool, ?xml:Fast )
    {
+      #if profileNMMLParser
+      var start:Float = haxe.Timer.stamp();
+      #end
+       
       project = inProject;
       process(path,inWarnUnknown,xml);
+
+      #if profileNMMLParser
+      var end:Float = haxe.Timer.stamp();
+      var diff:Float = end-start; 
+      Sys.println("NMMLParser time: " + diff);
+      #end
    }
 
    private function filter(text:String, include:Array<String> = null, exclude:Array<String> = null):Bool 
@@ -235,11 +246,18 @@ class NMMLParser
                var name = formatAttributeName(attribute);
                var value = substitute(element.att.resolve(attribute));
 
-               if (Reflect.hasField(project.app, name)) 
-                  Reflect.setField(project.app, name, value);
+               trySetField(project.app, name, value);
          }
       }
    }
+    
+   private function trySetField( o : Dynamic, field : String, value : Dynamic ) : Void {
+       try {
+            Reflect.setField(o, field, value);
+       }
+       catch(e:Dynamic) {}
+   }
+    
 
    private function parseWatchOSElement(element:Fast, extensionPath:String):Void 
    {
@@ -481,7 +499,7 @@ class NMMLParser
 
                if (glyphs != null) 
                   asset.glyphs = glyphs;
-
+                
                project.assets.push(asset);
             }
          }
@@ -1070,22 +1088,15 @@ class NMMLParser
                }
 
             case "height", "width", "fps", "antialiasing":
-               if (Reflect.hasField(project.window, name)) 
-                  Reflect.setField(project.window, name, Std.parseInt(value));
+                  trySetField(project.window, name, Std.parseInt(value));
 
             case "parameters", "ui":
                if (name=="ui" && value=="spritekit")
                   project.haxedefs.set("nme_spritekit", "1");
-               if (Reflect.hasField(project.window, name)) 
-                  Reflect.setField(project.window, name, Std.string(value));
+                  trySetField(project.window, name, Std.string(value));
 
             default:
-               if (Reflect.hasField(project.window, name)) 
-                  Reflect.setField(project.window, name, value == "true");
-               else
-               {
-                  //Log.error("Unknown window field: " + name);
-               }
+                  trySetField(project.window, name, value == "true");
          }
       }
    }


### PR DESCRIPTION
Parsing assets in a big project can be expensive. In Pakka Pets it takes 12.85 seconds. That can be  rough if all I'm doing is making a one line change to a haxe file. In an effort to decrease this, I tried compiling the NME tool using CPP. It now only takes 1.83 seconds! There was a nasty hitch that I ran into, Reflect.hasField() does not work on CPP for non-anonymous objects, which haxe spec says is okay, so I adjusted the setField calls in NMMLParser to just try and set fields and catch & ignore the error for fields that they do not support. I really like the speed at which you can edit neko files without compiling, but HXCPP_COMPILER_CACHE makes recompiling the build tool is very fast.

I've tested Pakka on mac, Pakka tests on mac, and DisplayingABitmap on mac.

Any side effects I might have missed?