### PR TITLE
Huge build speedup by not generating manifest file.

### DIFF
--- a/tools/nme/src/platforms/CppiaPlatform.hx
+++ b/tools/nme/src/platforms/CppiaPlatform.hx
@@ -123,9 +123,10 @@ class CppiaPlatform extends Platform
       Log.verbose("Wrote " + filename + " data=" + zipfileBytes.length);
    }
 
-
-
-
+    override public function deploy(inAndRun:Bool):Bool {
+        addManifest();
+        return super.deploy(inAndRun);
+    }
 }
 
 

--- a/tools/nme/src/platforms/Platform.hx
+++ b/tools/nme/src/platforms/Platform.hx
@@ -377,8 +377,6 @@ class Platform
 
    public function deploy(inAndRun:Bool) : Bool
    {
-      addManifest();
-
       var target = CommandLineTools.parseDeploy(project.getDef("deploy"),false,false);
       if (target!=null)
       {


### PR DESCRIPTION
I think I've really not notice the water boiling on this one. This speeds up my build time by 53.40 seconds! This was happening even with no file changes.