### PR TITLE
winrt adjust main compile and boot

### DIFF
--- a/project/ToolkitBuild.xml
+++ b/project/ToolkitBuild.xml
@@ -502,7 +502,8 @@
             <lib name="user32.lib" />
             <lib name="kernel32.lib" />
             <lib name="advapi32.lib" />
-            <lib name="${SUP_DIR}/windows/dxguid.lib"/>
+            <lib name="${SUP_DIR}/windows/dxguid.lib" unless="HXCPP_NO_WINXP_COMPAT || HXCPP_M64"/>
+	    <lib name="dxguid.lib" if="HXCPP_NO_WINXP_COMPAT || HXCPP_M64"/>
             <lib name="winmm.lib" />
             <lib name="imm32.lib"  />
             <lib name="ole32.lib" />
@@ -525,7 +526,6 @@
             <lib name="D3dcompiler.lib" />
          </section>
 
-
          <section if="linux">
             <lib name="${HXCPP}/lib/${BINDIR}/liblinuxcompat.a" />
             <lib name="-lpthread" />
@@ -537,7 +537,7 @@
    </target>
 
 
-    <files id="__main__" tags="haxe,main,static" replace="true" >
+    <files id="__main__" tags="haxe,main,static" replace="true" if="winrt">
       <depend files="hxcpp-depends"/>
       <depend name="${HXCPP}/include/hx/HxcppMain.h"/>
       <file name="${this_dir}/src/winrt/Main.cpp" />

--- a/project/src/common/ExternalInterface.cpp
+++ b/project/src/common/ExternalInterface.cpp
@@ -13,6 +13,9 @@
 #define NME_NO_CURL
 #define NME_NO_CAMERA
 #endif
+#if defined(HXCPP_JS_PRIME) || defined(HX_WINRT)
+#define NME_NO_LZMA
+#endif
 
 #ifdef ANDROID
 #include <android/log.h>
@@ -1906,19 +1909,23 @@ DEFINE_PRIM(nme_sv_get_buffered_percent, 1);
 
 // --- ManagedStage ----------------------------------------------------------------------
 
-#ifndef HX_WINRT
 
 value nme_managed_stage_create(value inW,value inH,value inFlags)
 {
+#ifdef HX_WINRT
+   return alloc_null();
+#else
    SetMainThread();
    ManagedStage *stage = new ManagedStage(val_int(inW),val_int(inH),val_int(inFlags));
    return ObjectToAbstract(stage);
+#endif
 }
 DEFINE_PRIM(nme_managed_stage_create,3);
 
 
 value nme_managed_stage_pump_event(value inStage,value inEvent)
 {
+#ifndef HX_WINRT
    ManagedStage *stage;
    if (AbstractToObject(inStage,stage))
    {
@@ -1926,12 +1933,12 @@ value nme_managed_stage_pump_event(value inStage,value inEvent)
       FromValue(event,inEvent);
       stage->PumpEvent(event);
    }
+#endif
    return alloc_null();
 }
 DEFINE_PRIM(nme_managed_stage_pump_event,2);
 
 
-#endif
 
 
 
@@ -5159,7 +5166,7 @@ DEFINE_PRIME1(nme_zip_decode);
 
 value nme_lzma_encode(value input_value)
 {
-#if !defined(HXCPP_JS_PRIME) && !defined(HX_WINRT)
+#if !defined(NME_NO_LZMA)
    buffer input_buffer = val_to_buffer(input_value);
    buffer output_buffer = alloc_buffer_len(0);
    Lzma::Encode(input_buffer, output_buffer);
@@ -5172,7 +5179,7 @@ DEFINE_PRIM(nme_lzma_encode,1);
 
 value nme_lzma_decode(value input_value)
 {
-#if !defined(HXCPP_JS_PRIME) && !defined(HX_WINRT)
+#if !defined(NME_NO_LZMA)
    buffer input_buffer = val_to_buffer(input_value);
    buffer output_buffer = alloc_buffer_len(0);
    Lzma::Decode(input_buffer, output_buffer);

--- a/project/src/winrt/Main.cpp
+++ b/project/src/winrt/Main.cpp
@@ -1,3 +1,4 @@
+#include <stdbool.h>
 #include <SDL_main.h>
 #include <hxcpp.h>
 #include <wrl.h>

--- a/tools/nme/src/platforms/WinrtPlatform.hx
+++ b/tools/nme/src/platforms/WinrtPlatform.hx
@@ -13,42 +13,12 @@ class WinrtPlatform extends WindowsPlatform
       super(inProject);
    }
 
-/*
-   override public function runHaxe()
-   {
-      var args = [haxeDir + "/build.hxml"];
-      if (project.debug)
-         args.push("-debug");
-
-      args.push("-D");
-      args.push("static_link");
-      args.push("-D");
-      args.push("ABI=-ZW");
-
-      runHaxeWithArgs(args);
-
-      buildWinRTMain();
-   }
-
-   public function buildWinRTMain()
-   {
-      var dest = haxeDir+"/cpp";
-      var projectDirectory = getOutputDir();
-      copyTemplateDir("winrt/static", dest );
-      var args = [ "run", "hxcpp", "BuildMain.xml" ];
-      if (project.debug)
-         args.push("-debug");
-      ProcessHelper.runCommand (dest, "haxelib", args);
-   }
-*/
-
    override public function getPlatformDir() : String { return "winrt"; }
    override public function getBinName() : String { return is64 ? "WinRT64" : "WinRT"; }
 
    override public function copyBinary():Void 
    {
-       FileHelper.copyFile(haxeDir + "/cpp/ApplicationMain" + (project.debug ? "-debug" : "") + ".exe", executablePath);
-      FileHelper.copyFile(haxeDir + "/cpp/Main" + (project.debug ? "-debug" : "") + ".exe", executablePath);
+      FileHelper.copyFile(haxeDir + "/cpp/ApplicationMain" + (project.debug ? "-debug" : "") + ".exe", executablePath);
    }
 
    override public function run(arguments:Array<String>):Void 


### PR DESCRIPTION
winrt needed to find nme_managed_stage_create from ExternalInterface at startup.

Fixes compile error 'FALSE': undeclared identifier

Included a NME_NO_LZMA define as NME_NO_CURL and NME_NO_CAMERA. These are practical for considering (*) other targets.  Furthermore, could be considered later for custom functionality for other targets, setting them from xml (command line).
*my

Thanks