### PR TITLE
PixelConvert GL_RGB 24-bit texture to 32 bit

### DIFF
--- a/project/src/opengl/OGLTexture.cpp
+++ b/project/src/opengl/OGLTexture.cpp
@@ -115,7 +115,7 @@ GLenum getTextureStorage(PixelFormat pixelFormat)
 {
    switch(pixelFormat)
    {
-      case pfRGB:      return GL_RGB;
+      case pfRGB:      return ARGB_STORE;
       case pfBGRA:     return ARGB_STORE;
       case pfBGRPremA: return ARGB_STORE;
       case pfAlpha: return GL_ALPHA;
@@ -146,7 +146,7 @@ GLenum getTransferOgl(PixelFormat pixelFormat)
 {
    switch(pixelFormat)
    {
-      case pfRGB:      return GL_RGB;
+      case pfRGB:      return ARGB_PIXEL;
       case pfBGRA:     return ARGB_PIXEL;
       case pfBGRPremA: return ARGB_PIXEL;
       case pfAlpha: return GL_ALPHA;
@@ -165,6 +165,8 @@ PixelFormat getTransferFormat(PixelFormat pixelFormat)
    switch(pixelFormat)
    {
       case pfRGB:
+         return SWAP_RB ? pfRGBA :pfBGRA;
+
       case pfLuma:
       case pfAlpha:
       case pfLumaAlpha:
@@ -244,11 +246,12 @@ public:
       PixelFormat buffer_format = getTransferFormat(fmt);
       GLenum channel= getOglChannelType(fmt);
 
-      int pw = BytesPerPixel(fmt);
+      //int pw = BytesPerPixel(fmt);
 
       bool copy_required = mSurface->GetBase() && (mTextureWidth!=mPixelWidth || mTextureHeight!=mPixelHeight || buffer_format!=fmt);
       if (copy_required)
       {
+         int pw = BytesPerPixel(buffer_format);
          buffer = (uint8 *)malloc(pw * mTextureWidth * mTextureHeight);
          int extraX =  mTextureWidth - mPixelWidth;
          if (extraX)


### PR DESCRIPTION
Letting NME do the conversion instead of the OpenGL driver internally.

Bug?: The value of "pw" was set for fmt (source) instead of "buffer_format"
(destination). https://github.com/haxenme/nme/compare/master...madrazo:bgrx?expand=1#diff-73ed1762b901143cf0e41fc05aab7a3cR249

Issue: https://github.com/haxenme/nme/issues/494

@hughsando so far this works but is there any mean to test it? Thanks!