### PR TITLE
Cppia compile fix

### DIFF
--- a/src/nme/app/AppEvent.hx
+++ b/src/nme/app/AppEvent.hx
@@ -1,6 +1,6 @@
 package nme.app;
 
-#if (cpp && hxcpp_api_level>=312)
+#if (cpp && !cppia && hxcpp_api_level>=312)
 import nme.native.NativeEvent;
 using cpp.NativeString;
 


### PR DESCRIPTION
Without this I get `/home/ibilon/Code/nme/src/nme/app/AppEvent.hx:40: characters 54-126 : Unsupported operation in cppia :CppCode`.
Not 100% sure about the fix.