### PR TITLE
SDL sound compiler fix on Mac

### DIFF
--- a/project/src/audio/SDLSound.cpp
+++ b/project/src/audio/SDLSound.cpp
@@ -934,7 +934,7 @@ public:
    }
    void setTransform(const SoundTransform &inTransform) 
    {
-      if (mMusic>=0)
+      if (mMusic && inTransform.volume>=0)
          Mix_VolumeMusic( inTransform.volume*MIX_MAX_VOLUME );
    }
 


### PR DESCRIPTION
On Mac latest xCode error:

error: ordered comparison between pointer and zero ('Mix_Music *' (aka '_Mix_Music *') and 'int')
      if (mMusic>=0)
          ~~~~~~^ ~
1 error generated.
#### Error building m64