### PR TITLE
WinRT Fix dependecy when building with VS2017

### DIFF
--- a/project/ToolkitBuild.xml
+++ b/project/ToolkitBuild.xml
@@ -539,7 +539,7 @@
          </section>
 
          <section if="winrt">
-            <lib name="kernel32.lib" />
+            <lib name="WindowsApp.lib" /><!--kernel32-->
             <lib name="d3d11.lib" />
             <lib name="Xaudio2.lib" />
             <lib name="Xinput.lib" />

--- a/templates/winrt/appx/AppxManifest.xml
+++ b/templates/winrt/appx/AppxManifest.xml
@@ -9,7 +9,11 @@
   </Properties>
   <Dependencies>
     <TargetDeviceFamily Name="::APP_TARGET::" MinVersion="::APP_MINVERSION::" MaxVersionTested="::APP_MAXVERSION::" />
-    <!--<PackageDependency Name="Microsoft.VCLibs.140.00.Debug" MinVersion="14.0.24210.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />-->    
+::if APP_DEBUG_DEPENDECY::
+    <PackageDependency Name="Microsoft.VCLibs.140.00.Debug" MinVersion="::APP_MINVERSION::" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
+::else::
+    <PackageDependency Name="Microsoft.VCLibs.140.00" MinVersion="::APP_MINVERSION::" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
+::end::
     ::foreach packageDependency:: <PackageDependency Name="::dependency::" MinVersion="::minversion::" Publisher="::publisher::" /></PackageDependency>::end::
   </Dependencies>
   <Resources>

--- a/tools/nme/src/platforms/WinrtPlatform.hx
+++ b/tools/nme/src/platforms/WinrtPlatform.hx
@@ -77,9 +77,10 @@ class WinrtPlatform extends WindowsPlatform
           Log.info("run: "+appxAUMID);
           var process4 = new sys.io.Process(kitsRoot10+'App Certification Kit\\microsoft.windows.softwarelogo.appxlauncher.exe', [appxAUMID]);
           //if (process4.exitCode() != 0) {
-          //   var message = process.stderr.readAll().toString();
-          //   Log.error("Cannot run. " + message);
-          // }
+             var message = process4.stderr.readAll().toString();
+             if(message.length>0)
+                Log.error("Cannot run. " + message);
+           //}
       }
    }
 
@@ -295,6 +296,8 @@ class WinrtPlatform extends WindowsPlatform
         }
         context.APP_MINVERSION = "10.0.14393.0";
         context.APP_MAXVERSION = "10.0.15063.400";
+        if(project.debug)
+           context.APP_DEBUG_DEPENDECY = true;
    }
 }
 


### PR DESCRIPTION
Needs the Microsoft.VCLibs.140.00/Microsoft.VCLibs.140.00.Debug
dependecy, otherwise crashes at startup because "vccorlib140_app.DLL" is
not found (used debugger/gflags to find out
 https://stackoverflow.com/questions/36315538/how-to-determine-which-dll-dependency-is-failing-to-load-in-windows-store-univer/43128358#43128358 )

Changed kernel32.lib to WindowsApp.lib

Compile for VS2017 with HXCPP using https://github.com/HaxeFoundation/hxcpp/pull/624