### PR TITLE
Cache the cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,13 @@
 language: objective-c
+
+env:
+  global:
+  - HXCPP_COMPILE_CACHE=~/hxcache
+
+cache:
+  directories:
+  - $HXCPP_COMPILE_CACHE
+
 before_install:
 - travis_retry brew install neko --HEAD
 - wget -c https://github.com/HaxeFoundation/haxe/releases/download/3.4.2/haxe-3.4.2-osx.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ before_install:
 - haxelib -notimeout install nme-toolkit
 - haxelib -notimeout install format
 - haxelib -notimeout install gm2d
+
 script:
 - cd $TRAVIS_BUILD_DIR/tools/nme
 - haxe compile.hxml


### PR DESCRIPTION
Travis CI has a cache feature, HXCPP_COMPILE_CACHE is a perfect candidate. In subsequent builds CI will be much faster! In my test commit this shaved 11m10s from the build!

![image](https://user-images.githubusercontent.com/220965/31582246-4f967cd4-b133-11e7-954d-9066d7a638a6.png)

https://docs.travis-ci.com/user/caching/#Arbitrary-directories
