### PR TITLE
implemented GL.getTranslatedShaderSourceANGLE, GL.debugMessageCallback

### DIFF
--- a/project/src/opengl/OGLExport.cpp
+++ b/project/src/opengl/OGLExport.cpp
@@ -1781,16 +1781,6 @@ DEFINE_PRIM(nme_gl_get_render_buffer_parameter,2);
 
 
 
-#ifdef NME_GLES3
-value nme_gl_bind_vertexarray(value inId )
-{
-   int id = getResourceId(inId,resoVertexarray);
-   glBindVertexArray(id);
-   return alloc_null();
-}
-DEFINE_PRIM(nme_gl_bind_vertexarray,1);
-#endif
-
 
 // --- Drawing -------------------------------
 

--- a/project/src/opengl/OGLExport.cpp
+++ b/project/src/opengl/OGLExport.cpp
@@ -2299,6 +2299,7 @@ sprintf(buf,"CALLBACK:%d: %s of %s severity, raised from %s: %s in %s",
     fprintf(stderr,"CALLBACK:%s\n", buf);
   gCurrentDebugMessage->onResult(buf);
 }
+#endif
 
 bool nme_debug_message_callback( value inCallback )
 {
@@ -2320,10 +2321,12 @@ bool nme_debug_message_callback( value inCallback )
 #endif
       return true;
    }
+#endif
+
    return false;
 }
 DEFINE_PRIME1(nme_debug_message_callback);
-#endif
+
 }
 
 extern "C" int nme_oglexport_register_prims() { return 0; }

--- a/project/src/opengl/OGLExport.cpp
+++ b/project/src/opengl/OGLExport.cpp
@@ -1455,6 +1455,29 @@ value nme_gl_get_shader_info_log(value inId)
 }
 DEFINE_PRIM(nme_gl_get_shader_info_log,1);
 
+#define TRANSLATED_SHADER_SOURCE_LENGTH_ANGLE              0x93A0
+value nme_gl_get_translated_shader_source(value inId)
+{
+   #ifdef NME_ANGLE
+   DBGFUNC("getShaderSource");
+   int id = getResource(inId,resoShader);
+
+   int len = 0;
+   glGetShaderiv(id,TRANSLATED_SHADER_SOURCE_LENGTH_ANGLE,&len);
+   if (len==0)
+      return alloc_null();
+   char *buf = new char[len+1];
+   glGetTranslatedShaderSourceANGLE(id,len+1,0,buf);
+   value result = alloc_string(buf);
+   delete [] buf;
+
+   return result;
+   #else
+   return alloc_null();
+   #endif
+}
+DEFINE_PRIM(nme_gl_get_translated_shader_source,1);
+
 
 value nme_gl_get_shader_source(value inId)
 {

--- a/src/nme/gl/GL.hx
+++ b/src/nme/gl/GL.hx
@@ -830,6 +830,11 @@ class GL
       return nme_gl_get_shader_source(shader.id);
    }
 
+   public static inline function getTranslatedShaderSourceANGLE(shader:GLShader):String
+   {
+      return nme_gl_get_translated_shader_source(shader.id);
+   }
+
    public static inline function getSupportedExtensions():Array<String>
    {
       var result = new Array<String>();
@@ -1310,6 +1315,8 @@ class GL
    private static var nme_gl_vertex_attrib4fv = load("nme_gl_vertex_attrib4fv", 2);
    private static var nme_gl_vertex_attrib_pointer = load("nme_gl_vertex_attrib_pointer", -1);
    private static var nme_gl_viewport = load("nme_gl_viewport", 4);
+   //angle
+   private static var nme_gl_get_translated_shader_source = load("nme_gl_get_translated_shader_source", 1);
    #else // not (neko||cpp)
 
    // Stub to get flixel to compile

--- a/src/nme/gl/GL.hx
+++ b/src/nme/gl/GL.hx
@@ -1176,6 +1176,13 @@ class GL
       nme_gl_viewport(x, y, width, height);
    }
 
+   public static inline function debugMessageCallback(onResult:String->Void):Bool
+   {
+      return nme_debug_message_callback(onResult);
+   }
+   private static var nme_debug_message_callback = PrimeLoader.load("nme_debug_message_callback", "ob");
+
+
    // Getters & Setters
    private static inline function get_drawingBufferHeight() { return Lib.current.stage.stageHeight; }
    private static inline function get_drawingBufferWidth() { return Lib.current.stage.stageWidth; }

--- a/src/nme/gl/Utils.hx
+++ b/src/nme/gl/Utils.hx
@@ -25,6 +25,8 @@ class Utils
       var fshader = createShader(inFragmentSource, GL.FRAGMENT_SHADER);
       GL.attachShader(program, vshader);
       GL.attachShader(program, fshader);
+      program.shaders[0] = vshader;
+      program.shaders[1] = fshader;
       GL.linkProgram(program);
       if (GL.getProgramParameter(program, GL.LINK_STATUS)==0)
       {


### PR DESCRIPTION
Gets HLSL source from shader (Windows ANGLE target).  Usage:

```
var shaderProgram = nme.gl.Utils.createProgram(vs, ps);
var hlslSource =
nme.gl.GL.getTranslatedShaderSourceANGLE(shaderProgram.shaders[1]);
trace( ((hlslSource.split("// COMPILER INPUT HLSL BEGIN")[1]).split("//
COMPILER INPUT HLSL END"))[0] );
```
shaderProgram.shaders[0] for vs and shaderProgram.shaders[1] for ps