### PR TITLE
NME_GLES3

### DIFF
--- a/project/ToolkitBuild.xml
+++ b/project/ToolkitBuild.xml
@@ -4,10 +4,22 @@
    <set name="mac" value="1" if="macos" />
    <set name="native_toolkit_sdl_static" value="1" if="static_link" />
 
+
+   <set name="NME_ANGLE" value="1" if="windows||winrt" unless="NME_NO_ANGLE" />
+   <set name="NATIVE_TOOLKIT_SDL_ANGLE" value="1" if="NME_ANGLE" />
+   <set name="NATIVE_TOOLKIT_STATIC_ANGLE" value="1" if="NME_ANGLE" />
+
+   <!-- Uncomment to default GLES3 compatibility-->
+   <!--<set name="NME_GLES3" value="1" if="NME_ANGLE" unless="NME_FORCE_GLES2"/>-->
+   <!--<set name="NME_GLES3" value="1" unless="NME_FORCE_GLES2"/>-->
+
    <!-- Require Android 2.3+ -->
-   <set name="PLATFORM" value="android-9" if="android" />
-   <set name="PLATFORM" value="android-14" if="HXCPP_X86" />
-   <set name="PLATFORM" value="android-21" if="HXCPP_ARM64" />
+   <section if="android">
+      <set name="PLATFORM" value="android-9"/>
+      <set name="PLATFORM" value="android-14" if="HXCPP_X86" />
+      <set name="PLATFORM" value="android-18" if="NME_GLES3"/>
+      <set name="PLATFORM" value="android-21" if="HXCPP_ARM64" />
+   </section>
    <set name="HXCPP_CPP11" value="1" />
 
    <set name="exe_link" value="1" if="HXCPP_JS_PRIME" />
@@ -19,10 +31,6 @@
    <set name="xcompile" value="1" if="winrpi" />
    <set name="rpi" value="1" if="winrpi" />
    <set name="sdl_rpi" value="1" if="winrpi" />
-
-   <set name="NME_ANGLE" value="1" if="windows||winrt" unless="NME_NO_ANGLE" />
-   <set name="NATIVE_TOOLKIT_SDL_ANGLE" value="1" if="NME_ANGLE" />
-   <set name="NATIVE_TOOLKIT_STATIC_ANGLE" value="1" if="NME_ANGLE" />
 
    <include name="${HXCPP}/build-tool/BuildCommon.xml"/>
    <!-- 
@@ -205,6 +213,7 @@
       <compilerflag value="-DNME_WORKER_THREADS" if="NME_WORKER_THREADS" />
       <compilerflag value="-DNME_ANGLE" if="NME_ANGLE" />
       <compilerflag value="-I${ANGLE_DIR}/include" if="NME_ANGLE" />
+      <compilerflag value="-DNME_GLES3" if="NME_GLES3" />
 
       <cache value="1" unless="winrpi" />
       <cache value="1" asLibrary="true" if="winrpi" />
@@ -496,20 +505,23 @@
          <section if="android">
             <lib name="-ldl" />
             <lib name="-landroid" />
-            <lib name="-lGLESv2" />
+            <lib name="-lGLESv2" unless="NME_GLES3"/>
+            <lib name="-lGLESv3" if="NME_GLES3"/>
             <lib name="-lEGL" />
             <lib name="-lz" />
          </section>
 
          <section if="rpi" unless="winrpi" >
-            <lib name="/opt/vc/lib/libGLESv2.so" />
+            <lib name="/opt/vc/lib/libGLESv2.so" unless="NME_GLES3"/>
+            <lib name="/opt/vc/lib/libGLESv3.so" if="NME_GLES3"/>
             <lib name="/opt/vc/lib/libEGL.so" />
             <lib name="/opt/vc/lib/libbcm_host.so" />
          </section>
 
          <section if="rpi winrpi" >
             <libpath name="${haxelib:winrpi}/lib" />
-            <lib name="-lGLESv2" />
+            <lib name="-lGLESv2" unless="NME_GLES3"/>
+            <lib name="-lGLESv3" if="NME_GLES3"/>
             <lib name="-lEGL" />
             <lib name="-lvcos" />
             <lib name="-lvchiq_arm" />

--- a/project/include/Hardware.h
+++ b/project/include/Hardware.h
@@ -130,6 +130,9 @@ public:
    virtual void DestroyShader(unsigned int inShader)=0;
    virtual void DestroyFramebuffer(unsigned int inBuffer)=0;
    virtual void DestroyRenderbuffer(unsigned int inBuffer)=0;
+   #ifdef NME_GLES3
+   virtual void DestroyVertexarray(unsigned int inBuffer)=0;
+   #endif
    
    #ifdef NME_S3D
    virtual void EndS3DRender()=0;

--- a/project/src/opengl/OGL.h
+++ b/project/src/opengl/OGL.h
@@ -8,6 +8,9 @@
    #define NME_GLES
    #define GL_GLEXT_PROTOTYPES
 
+   #ifdef NME_GLES3
+   #include <GLES3/gl3.h>
+   #endif
    #include <GLES2/gl2.h>
    #include <GLES2/gl2ext.h>
 
@@ -15,6 +18,10 @@
 
    #define NME_GLES
 
+   #ifdef NME_GLES3
+   #include <GLES3/gl3.h>
+   #define __gl2_h_ //Not needed for Android Platform >= 21
+   #endif
    #include <GLES2/gl2.h>
    #include <GLES2/gl2ext.h>
 
@@ -31,6 +38,10 @@
    #include <OpenGLES/ES1/glext.h>
    #include <OpenGLES/ES2/gl.h>
    #include <OpenGLES/ES2/glext.h>
+   #ifdef NME_GLES3
+   #include <OpenGLES/ES3/gl.h>
+   #include <OpenGLES/ES3/glext.h>
+   #endif
 
    //typedef CAEAGLLayer *WinDC;
    //typedef EAGLContext *GLCtx;

--- a/project/src/opengl/OGLExport.cpp
+++ b/project/src/opengl/OGLExport.cpp
@@ -1386,19 +1386,18 @@ value nme_gl_shader_source(value inId,value inSource)
    DBGFUNC("shaderSource");
    int id = getResource(inId,resoShader);
    HxString source = valToHxString(inSource);
+   if (source.length<=0)   
+      return alloc_null();
+      
    const char *lines = source.c_str();
    
    #ifdef NME_GLES
-   // TODO - do something better here
-   if (lines[0] == '#') { // Skip add precision if starts with #version
-      glShaderSource(id,1,&lines,0);
-      return;
+   if (lines[0]!='#')
+   {
+      char* buffer = (char*)malloc(source.length + 29);
+      sprintf(buffer, "precision mediump float;\n%s", lines);
+      lines = buffer;
    }
-
-   std::string buffer;
-   buffer = std::string("precision mediump float;\n") + hxToStdString(source);
-   lines = buffer.c_str();
-
    #endif
 
    glShaderSource(id,1,&lines,0);

--- a/project/src/opengl/OGLExport.cpp
+++ b/project/src/opengl/OGLExport.cpp
@@ -1388,17 +1388,14 @@ value nme_gl_shader_source(value inId,value inSource)
    HxString source = valToHxString(inSource);
    const char *lines = source.c_str();
    
-   #ifdef NME_GLES3
-	if (strcmp("#version", lines)) { 
-	   glShaderSource(id,1,&lines,0);
-	   return alloc_null();
-   }
-   #endif
    #ifdef NME_GLES
    // TODO - do something better here
-   std::string buffer;
-   buffer = std::string("precision mediump float;\n") + hxToStdString(source);
-   lines = buffer.c_str();
+   // Skip add precision if starts with #version
+   if (!strcmp("#version", lines)) { 
+      std::string buffer;
+      buffer = std::string("precision mediump float;\n") + hxToStdString(source);
+      lines = buffer.c_str();
+   }
    #endif
 
    glShaderSource(id,1,&lines,0);

--- a/project/src/opengl/OGLExport.cpp
+++ b/project/src/opengl/OGLExport.cpp
@@ -1390,12 +1390,15 @@ value nme_gl_shader_source(value inId,value inSource)
    
    #ifdef NME_GLES
    // TODO - do something better here
-   // Skip add precision if starts with #version
-   if (!strcmp("#version", lines)) { 
-      std::string buffer;
-      buffer = std::string("precision mediump float;\n") + hxToStdString(source);
-      lines = buffer.c_str();
+   if (lines[0] == '#') { // Skip add precision if starts with #version
+      glShaderSource(id,1,&lines,0);
+      return;
    }
+
+   std::string buffer;
+   buffer = std::string("precision mediump float;\n") + hxToStdString(source);
+   lines = buffer.c_str();
+
    #endif
 
    glShaderSource(id,1,&lines,0);

--- a/project/src/opengl/OGLExport.cpp
+++ b/project/src/opengl/OGLExport.cpp
@@ -46,6 +46,9 @@ enum ResoType
    resoProgram, //4
    resoFramebuffer, //5
    resoRenderbuffer, //6
+   #ifdef NME_GLES3
+   resoVertexarray, //7
+   #endif
 };
 
 const char *getTypeString(int inType)
@@ -59,6 +62,9 @@ const char *getTypeString(int inType)
       case resoProgram: return "Program";
       case resoFramebuffer: return "Framebuffer";
       case resoRenderbuffer: return "Renderbuffer";
+      #ifdef NME_GLES3
+      case resoVertexarray: return "Vertexarray";
+      #endif
    }
    return "Unknown";
 }
@@ -306,6 +312,11 @@ public:
             case resoRenderbuffer:
                ctx->DestroyRenderbuffer(id);
                break;
+            #ifdef NME_GLES3
+            case resoVertexarray:
+               ctx->DestroyVertexarray(id);
+               break;
+            #endif
          }
       }
       type = resoNone;
@@ -793,7 +804,9 @@ GL_GEN_RESO(buffer,glGenBuffers,resoBuffer)
 
 GL_GEN_RESO(framebuffer,glGenFramebuffers,resoFramebuffer)
 GL_GEN_RESO(render_buffer,glGenRenderbuffers,resoRenderbuffer)
-
+#ifdef NME_GLES3
+GL_GEN_RESO(vertexarray,glGenVertexArrays,resoVertexarray)
+#endif
 
 // --- Stencil -------------------------------------------
 
@@ -1374,6 +1387,13 @@ value nme_gl_shader_source(value inId,value inSource)
    int id = getResource(inId,resoShader);
    HxString source = valToHxString(inSource);
    const char *lines = source.c_str();
+   
+   #ifdef NME_GLES3
+	if (strcmp("#version", lines)) { 
+	   glShaderSource(id,1,&lines,0);
+	   return alloc_null();
+   }
+   #endif
    #ifdef NME_GLES
    // TODO - do something better here
    std::string buffer;
@@ -1755,6 +1775,19 @@ value nme_gl_get_render_buffer_parameter(value target, value pname)
    return alloc_int(result);
 }
 DEFINE_PRIM(nme_gl_get_render_buffer_parameter,2);
+
+
+
+#ifdef NME_GLES3
+value nme_gl_bind_vertexarray(value inId )
+{
+   int id = getResourceId(inId,resoVertexarray);
+   glBindVertexArray(id);
+   return alloc_null();
+}
+DEFINE_PRIM(nme_gl_bind_vertexarray,1);
+#endif
+
 
 // --- Drawing -------------------------------
 

--- a/project/src/opengl/OpenGLContext.cpp
+++ b/project/src/opengl/OpenGLContext.cpp
@@ -155,6 +155,18 @@ public:
          glDeleteRenderbuffers(1,&inBuffer);
    }
 
+   #ifdef NME_GLES3
+   void DestroyVertexarray(unsigned int inBuffer)
+   {
+      if ( !IsMainThread() )
+      {
+         mHasZombie = true;
+         mZombieVertexarrays.push_back(inBuffer);
+      }
+      else
+         glDeleteVertexArrays(1,&inBuffer);
+   }
+   #endif
 
    void OnContextLost()
    {
@@ -164,6 +176,9 @@ public:
       mZombieShaders.resize(0);
       mZombieFramebuffers.resize(0);
       mZombieRenderbuffers.resize(0);
+      #ifdef NME_GLES3
+      mZombieVertexarrays.resize(0);
+	  #endif
       mHasZombie = false;
    }
 
@@ -277,6 +292,15 @@ public:
                glDeleteRenderbuffers(mZombieRenderbuffers.size(),&mZombieRenderbuffers[0]);
                mZombieRenderbuffers.resize(0);
             }
+            #ifdef NME_GLES3
+            if (mZombieVertexarrays.size())
+            {
+               #ifndef NME_NO_GLES3COMPAT
+               glDeleteVertexArrays(mZombieVertexarrays.size(),&mZombieVertexarrays[0]);
+               #endif
+               mZombieVertexarrays.resize(0);
+            }
+			#endif
          }
 
 
@@ -316,7 +340,9 @@ public:
       mZombieShaders.resize(0);
       mZombieFramebuffers.resize(0);
       mZombieRenderbuffers.resize(0);
-
+      #ifdef NME_GLES3
+      mZombieVertexarrays.resize(0);
+      #endif
       ReloadExtentions();
    }
 
@@ -771,6 +797,9 @@ public:
    QuickVec<GLuint> mZombieShaders;
    QuickVec<GLuint> mZombieFramebuffers;
    QuickVec<GLuint> mZombieRenderbuffers;
+   #ifdef NME_GLES3
+   QuickVec<GLuint> mZombieVertexarrays;
+   #endif
 
    GPUProg *mProg[PROG_COUNT];
 

--- a/project/src/sdl2/SDL2Stage.cpp
+++ b/project/src/sdl2/SDL2Stage.cpp
@@ -1809,9 +1809,13 @@ void CreateMainFrame(FrameCreationCallback inOnFrame, int inWidth, int inHeight,
    if (fullscreen) requestWindowFlags |= FullscreenMode; //SDL_WINDOW_FULLSCREEN_DESKTOP;
    
    #ifdef NME_ANGLE
+   int major = 2; 
+   #ifdef NME_GLES3
+   major = 3;
+   #endif
    SDL_GL_SetAttribute(SDL_GL_CONTEXT_EGL, 1); 
    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES); 
-   SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2); 
+   SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, major); 
    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0); 
    #endif
 
@@ -1944,6 +1948,16 @@ void CreateMainFrame(FrameCreationCallback inOnFrame, int inWidth, int inHeight,
          sgIsOGL2 = false;
       }
       
+      #if defined(NME_ANGLE) && defined(NME_GLES3) 
+      if (!renderer && opengl && major>2) 
+      {
+         fprintf(stderr, "GLES3 is not available. Retrying with GLES2. (%s)\n", SDL_GetError());
+         major = 2;
+         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, major); 
+         SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0); 
+      }
+      else
+      #endif
       if (!renderer && (inFlags & wfHW_AA_HIRES || inFlags & wfHW_AA)) {
          // if no window was created and AA was enabled, disable AA and try again
          fprintf(stderr, "Multisampling is not available. Retrying without. (%s)\n", SDL_GetError());

--- a/src/nme/gl/GL3.hx
+++ b/src/nme/gl/GL3.hx
@@ -1,0 +1,25 @@
+package nme.gl;
+
+@:nativeProperty
+class GL3
+{
+   #if (gles3 && !flash)
+
+   public static inline function bindVertexArray(vertexarray:GLVertexArray):Void
+   {
+      nme_gl_bind_vertexarray(vertexarray);
+   }
+
+   public static inline function createVertexArray():GLVertexArray
+   {
+      return new GLVertexArray(GL.version, nme_gl_create_vertexarray());
+   }
+
+
+   // Native Methods
+   private static var nme_gl_create_vertexarray = GL.load("nme_gl_create_vertexarray", 0);
+   private static var nme_gl_bind_vertexarray = GL.load("nme_gl_bind_vertexarray", 1);
+
+   #end
+}
+

--- a/src/nme/gl/GLVertexArray.hx
+++ b/src/nme/gl/GLVertexArray.hx
@@ -1,0 +1,18 @@
+package nme.gl;
+#if (gles3 && !flash)
+
+@:nativeProperty
+class GLVertexArray extends GLObject 
+{
+   public function new(inVersion:Int, inId:Dynamic) 
+   {
+      super(inVersion, inId);
+   }
+
+   override function getType():String 
+   {
+      return "VertexArray";
+   }
+}
+
+#end


### PR DESCRIPTION
Initial GLES3

 All C++ changes are within a "#define NME_GLES3" and Haxe's within #if gles3
 They are not activated so it doesn't modify current behaivor and should be safe to pull. 

To use it, build nme/project with -DNME_GLES3 flag or uncomment on
ToolkitBuild.xml
Then use -Dgles3 flag when compiling a haxe NME sample.  

Tested on Windows (Angle) with https://github.com/madrazo/nme-opengl-tutorials
tutorials 1 to 5, with both -Dgles3 and without (current gles2).  

Needs small patch for SDL nme-toolkit: https://github.com/native-toolkit/sdl/pull/11/files
(it is still safe but will get a GLES2 context without this change)

Thanks