### PR TITLE
Add winrt VCLibs dependency

### DIFF
--- a/templates/winrt/appx/AppxManifest.xml
+++ b/templates/winrt/appx/AppxManifest.xml
@@ -10,6 +10,7 @@
   <Dependencies>
     <TargetDeviceFamily Name="::APP_TARGET::" MinVersion="::APP_MINVERSION::" MaxVersionTested="::APP_MAXVERSION::" />
     <!--<PackageDependency Name="Microsoft.VCLibs.140.00.Debug" MinVersion="14.0.24210.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />-->    
+    <PackageDependency Name="Microsoft.VCLibs.140.00" MinVersion="10.0.14393.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
     ::foreach packageDependency:: <PackageDependency Name="::dependency::" MinVersion="::minversion::" Publisher="::publisher::" /></PackageDependency>::end::
   </Dependencies>
   <Resources>


### PR DESCRIPTION
Needs the Microsoft.VCLibs.140.00 or Microsoft.VCLibs.140.00.Debug
dependecy, otherwise crashes at startup because "vccorlib140_app.DLL" is
not found (used debugger/gflags to find out

https://stackoverflow.com/questions/36315538/how-to-determine-which-dll-dependency-is-failing-to-load-in-windows-store-univer/43128358#43128358
)