### PR TITLE
add build.xml to findProjectFile

### DIFF
--- a/tools/nme/src/CommandLineTools.hx
+++ b/tools/nme/src/CommandLineTools.hx
@@ -849,6 +849,8 @@ class CommandLineTools
          return PathHelper.combine(path, "project.xml");
       else if (FileSystem.exists(PathHelper.combine(path, "Project.xml"))) 
          return PathHelper.combine(path, "Project.xml");
+      else if (FileSystem.exists(PathHelper.combine(path, "build.xml"))) 
+         return PathHelper.combine(path, "build.xml");
       else
       {
          var files = FileSystem.readDirectory(path);


### PR DESCRIPTION
help compiling stablexui samples, such as 02first, with only "nme" shortcut (instead of "nme build.xml")
https://github.com/RealyUniqueName/StablexUI/tree/master/samples/02_first