### PR TITLE
DisplayingABitmap -gradle fixes

### DIFF
--- a/templates/android/PROJ-gradle/app/build.gradle
+++ b/templates/android/PROJ-gradle/app/build.gradle
@@ -17,6 +17,11 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    sourceSets {
+        main {
+            assets.srcDirs = ['../assets']
+        }
+    }
 }
 
 dependencies {

--- a/tools/nme/src/platforms/AndroidPlatform.hx
+++ b/tools/nme/src/platforms/AndroidPlatform.hx
@@ -238,6 +238,9 @@ class AndroidPlatform extends Platform
       {
          var assemble = (project.certificate != null) ? "assembleRelease" : "assembleDebug";
 
+         if(PlatformHelper.hostPlatform==Platform.MAC)
+            ProcessHelper.runCommand(outputDir, 'chmod', ['+x', './gradlew']);
+          
          var exe = PlatformHelper.hostPlatform==Platform.WINDOWS ? "./gradlew.bat" : "./gradlew";
          ProcessHelper.runCommand(outputDir, exe, [ assemble ]);
       }


### PR DESCRIPTION
- Fixes gradlew permission denied on mac for `nme test android -gradle`
- Fixes DisplayingABitmap showing a blank white screen for `nme test android -gradle`

Notes:
This diff closes https://github.com/haxenme/nme/issues/530