### PR TITLE
Improving content type handling

### DIFF
--- a/src/nme/display/LoaderInfo.hx
+++ b/src/nme/display/LoaderInfo.hx
@@ -61,15 +61,19 @@ class LoaderInfo extends URLLoader
       var dot = pendingURL.lastIndexOf(".");
       var extension = dot > 0 ? pendingURL.substr(dot + 1).toLowerCase() : "";
 
-      contentType = switch(extension) 
-      {
-         case "swf": "application/x-shockwave-flash";
-         case "jpg","jpeg": "image/jpeg";
-         case "png": "image/png";
-         case "gif": "image/gif";
-         default:
+      if(request.contentType == null ||
+        request.contentType.length == 0 ||
+        request.contentType == "application/x-www-form-urlencoded")
+        contentType = switch(extension)
+        {
+            case "swf": "application/x-shockwave-flash";
+            case "jpg","jpeg": "image/jpeg";
+            case "png": "image/png";
+            case "gif": "image/gif";
+            default:
             throw "Unrecognized file " + pendingURL;
-      }
+        }
+
 
       url = null;
 


### PR DESCRIPTION
If request content type not empty, means user expecting something else, do not override it.