### PR TITLE
Android -gradle compile fixes

### DIFF
--- a/templates/android/PROJ-gradle/app/build.gradle
+++ b/templates/android/PROJ-gradle/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion ::ANDROID_TARGET_SDK_VERSION::
     buildToolsVersion "28.0.3"
     defaultConfig {
         applicationId "::APP_PACKAGE::"

--- a/templates/android/PROJ-gradle/gradle.properties
+++ b/templates/android/PROJ-gradle/gradle.properties
@@ -9,7 +9,7 @@
 
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx1536m
+# org.gradle.jvmargs=-Xmx1536m
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/templates/android/extension-api/build.gradle
+++ b/templates/android/extension-api/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'android-library'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion ::ANDROID_TARGET_SDK_VERSION::
     buildToolsVersion "28.0.3"
 
     sourceSets {

--- a/tools/nme/src/platforms/AndroidPlatform.hx
+++ b/tools/nme/src/platforms/AndroidPlatform.hx
@@ -208,6 +208,8 @@ class AndroidPlatform extends Platform
       for( k in project.androidConfig.extensions.keys())
          extensions.push(k);
       context.ANDROID_EXTENSIONS =extensions;
+
+      context.ANDROID_SDK = StringTools.replace(project.environment.get("ANDROID_SDK"),"\\","/");
       
       if(gradle)
          setGradleLibraries();


### PR DESCRIPTION
These fixes android build:
Using compileSdkVersion different of 26, 
Inverted slash in ANDROID_SDK, 
and commented out -Xmx1536m flag for gradle (JDK?) memory error.