### PR TITLE
Missing Dynamic

### DIFF
--- a/src/nme/net/URLVariables.hx
+++ b/src/nme/net/URLVariables.hx
@@ -2,7 +2,7 @@ package nme.net;
 #if (!flash)
 
 @:nativeProperty
-class URLVariables
+class URLVariables implements Dynamic
 {
    public function new(?inEncoded:String) 
    {


### PR DESCRIPTION
If class not Dynamic:
var q = nme.net.URLVariables(); q.name="ddd";
end with error: Error:(23, 41) nme.net.URLVariables has no field name

This was working before.
https://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/net/URLVariables.html