### PR TITLE
Null check for GLSurfaceOnTouch after onDestroy

### DIFF
--- a/templates/android/java/org/haxe/nme/GameActivity.java
+++ b/templates/android/java/org/haxe/nme/GameActivity.java
@@ -1175,6 +1175,11 @@ implements SensorEventListener
    
    public static void popupKeyboard(final  int inMode, final  String inContent, final int inType)
    {
+      if(activity == null) {
+        Log.i("VIEW","popupKeyboard occured after destruction, ignoring...");
+        return;
+      }
+        
       activity.mHandler.post(new Runnable() {
          @Override public void run()
          {


### PR DESCRIPTION
Potential fix for #593 

It appears  that NME.popupKeyboard is getting called inside NME.onTouch.
When it is called, activity.mHandler is null.
The only time activity is set to null is in onDestroy. 
Since we cannot unsubscribe from `onTouchEvent` in MainView.java, let's add a null check.

```
Fatal Exception: java.lang.NullPointerException: Attempt to read from field 'android.os.Handler org.haxe.nme.GameActivity.mHandler' on a null object reference
       at org.haxe.nme.GameActivity.popupKeyboard(GameActivity.java:1246)
       at org.haxe.nme.NME.onTouch(NME.java)
       at org.haxe.nme.MainView$6.run(MainView.java:410)
       at android.opengl.GLSurfaceView$GLThread.guardedRun(GLSurfaceView.java:1500)
       at android.opengl.GLSurfaceView$GLThread.run(GLSurfaceView.java:1270)
```