### PR TITLE
getTranslatedShaderSourceANGLE implemented

### DIFF
--- a/project/src/opengl/OGLExport.cpp
+++ b/project/src/opengl/OGLExport.cpp
@@ -1578,6 +1578,29 @@ value nme_gl_get_shader_info_log(value inId)
 }
 DEFINE_PRIM(nme_gl_get_shader_info_log,1);
 
+#define TRANSLATED_SHADER_SOURCE_LENGTH_ANGLE              0x93A0
+value nme_gl_get_translated_shader_source(value inId)
+{
+   #ifdef NME_ANGLE
+   DBGFUNC("getShaderSource");
+   int id = getResource(inId,resoShader);
+
+    int len = 0;
+   glGetShaderiv(id,TRANSLATED_SHADER_SOURCE_LENGTH_ANGLE,&len);
+   if (len==0)
+      return alloc_null();
+   char *buf = new char[len+1];
+   glGetTranslatedShaderSourceANGLE(id,len+1,0,buf);
+   value result = alloc_string(buf);
+   delete [] buf;
+
+    return result;
+   #else
+   return alloc_null();
+   #endif
+}
+DEFINE_PRIM(nme_gl_get_translated_shader_source,1);
+
 value nme_gl_get_shader_source(value inId)
 {
    DBGFUNC("getShaderSource");

--- a/src/nme/gl/GL.hx
+++ b/src/nme/gl/GL.hx
@@ -1605,6 +1605,12 @@ class GL
    }
 
 
+   //Angle
+   public static inline function getTranslatedShaderSourceANGLE(shader:GLShader):String
+   {
+      return nme_gl_get_translated_shader_source(shader.id);
+   }
+
 
    // Getters & Setters
    private static inline function get_drawingBufferHeight() { return Lib.current.stage.stageHeight; }
@@ -1777,6 +1783,8 @@ class GL
    private static var nme_gl_read_buffer = PrimeLoader.load("nme_gl_read_buffer", "iv");
    private static var nme_gl_tex_image_3d = PrimeLoader.load("nme_gl_tex_image_3d", "iiiiiiiiioiv");
    private static var nme_gl_compressed_tex_image_3d = PrimeLoader.load("nme_gl_compressed_tex_image_3d", "iiiiiiiioiv");
+
+   private static var nme_gl_get_translated_shader_source = load("nme_gl_get_translated_shader_source", 1);
 
    #else // not (neko||cpp)
 


### PR DESCRIPTION
Updated from https://github.com/haxenme/nme/pull/518/files

Tested with 

```
 var fragShader:String =
"precision mediump float;\n" +
"void main(){
    // Output color = red
    gl_FragColor = vec4(1.0,0.0,0.0,1.0);
}
";

        var vertShader:String =
"precision mediump float;\n" +
"// Input vertex data, different for all executions of this shader.
uniform vec3 vertexPosition_modelspace;
void main(){
    gl_Position.xyz = vertexPosition_modelspace;
    gl_Position.w = 1.0;
}
";

var shaderProgram = nme.gl.Utils.createProgram(vertShader, fragShader);
var hlslSource =
nme.gl.GL.getTranslatedShaderSourceANGLE(shaderProgram.getShaders()[1]);
trace( ((hlslSource.split("// COMPILER INPUT HLSL BEGIN")[1]).split("// COMPILER INPUT HLSL END"))[0] );
```

Output
```
// GLSL
//
// #define texture texture2D// precision mediump float;// void main(){//     // Output color = red //     gl_FragColor = vec4(1.0,0.0,0.0,1.0);// }

#ifdef ANGLE_ENABLE_LOOP_FLATTEN
#define LOOP [loop]
#define FLATTEN [flatten]
#else
#define LOOP
#define FLATTEN
#endif
// Varyings

static float4 gl_Color[1] =
{
    float4(0, 0, 0, 0)
};

cbuffer DriverConstants : register(b1)
{
};

#define GL_USES_FRAG_COLOR
void gl_main()
{
(gl_Color[0] = float4(1.0, 0.0, 0.0, 1.0));
}
;
struct PS_INPUT
{
    float4 dx_Position : SV_Position;
    float4 gl_Position : TEXCOORD0;
};

struct PS_OUTPUT
{
    float4 gl_Color0 : SV_TARGET0;
};

PS_OUTPUT generateOutput()
{
    PS_OUTPUT output;
    output.gl_Color0 = gl_Color[0];
    return output;
}

PS_OUTPUT main(PS_INPUT input)
{

    gl_main();

    return generateOutput();
}
```