### PR TITLE
[android] remove unneeded dependencies

### DIFF
--- a/templates/android/PROJ-gradle/app/build.gradle
+++ b/templates/android/PROJ-gradle/app/build.gradle
@@ -24,8 +24,6 @@ dependencies {
     androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    api 'com.android.support:appcompat-v7:24.2.1'
-    api 'com.android.support:support-v4:24.2.1'
     ::if ANDROID_BILLING::
     api 'com.android.billingclient:billing:1.0'
     ::end::


### PR DESCRIPTION
```
cd samples/DisplayingABitmap/
haxelib run nme android -toolkit -gradle
```

This works just fine without these dependencies. They caused a confusing collision with an extension I had. Are they used for something in NME? If not we should remove them.