### PR TITLE
GL.debugMessageCallback

### DIFF
--- a/project/include/Display.h
+++ b/project/include/Display.h
@@ -559,6 +559,7 @@ enum WindowFlags
    wfSingleInstance = 0x00000800,
    wfScaleBase      = 0x00001000,
    wfScaleMask      = 0x0000f000,
+   wfGlDebug        = 0x00010000, //1<<16
 };
 
 enum WindowScaleMode

--- a/project/src/opengl/OGLExport.cpp
+++ b/project/src/opengl/OGLExport.cpp
@@ -2407,7 +2407,7 @@ value nme_gl_get_tex_parameter(value inTarget,value inPname)
 DEFINE_PRIM(nme_gl_get_tex_parameter,2);
 
 
-#if defined(GL_KHR_debug) && GL_KHR_debug && (!defined(NME_GLES)|| defined(GL_VERSION_4_3))
+#if defined(GL_KHR_debug) && GL_KHR_debug && (!defined(NME_GLES)|| defined(GL_VERSION_4_3)) &&  !defined(NME_MACOS)
 #define NME_GL_DEBUG
 #endif
 

--- a/project/src/opengl/OGLExport.cpp
+++ b/project/src/opengl/OGLExport.cpp
@@ -2407,7 +2407,7 @@ value nme_gl_get_tex_parameter(value inTarget,value inPname)
 DEFINE_PRIM(nme_gl_get_tex_parameter,2);
 
 
-
+#ifdef GL_KHR_debug
 struct DebugMessage
 {
    DebugMessage() : callback(0) { }
@@ -2475,10 +2475,11 @@ static void GL_APIENTRY Callback(GLenum source,
    buf += std::string("]");
    gCurrentDebugMessage->onResult(buf.c_str());
 }
-
+#endif
 
 bool nme_gl_debug_message_callback( value inCallback )
 {
+#ifdef GL_KHR_debug
    if(GL_KHR_debug)
    {
       if (gCurrentDebugMessage)
@@ -2493,6 +2494,7 @@ bool nme_gl_debug_message_callback( value inCallback )
 
       return true;
    }
+#endif
    return false;
 }
 DEFINE_PRIME1(nme_gl_debug_message_callback);
@@ -2500,6 +2502,7 @@ DEFINE_PRIME1(nme_gl_debug_message_callback);
 
 value nme_gl_debug_message_insert(value inMsg)
 {
+#ifdef GL_KHR_debug
    DBGFUNC("debugMessageInsert");
    HxString msg = valToHxString(inMsg);
    glDebugMessageInsertKHR( GL_DEBUG_SOURCE_APPLICATION_KHR,
@@ -2508,6 +2511,7 @@ value nme_gl_debug_message_insert(value inMsg)
       GL_DEBUG_SEVERITY_NOTIFICATION_KHR,
       msg.size(),
       msg.c_str() );
+ #endif
    return alloc_null();
 }
 DEFINE_PRIM(nme_gl_debug_message_insert,1);

--- a/project/src/opengl/OGLExport.cpp
+++ b/project/src/opengl/OGLExport.cpp
@@ -2407,7 +2407,16 @@ value nme_gl_get_tex_parameter(value inTarget,value inPname)
 DEFINE_PRIM(nme_gl_get_tex_parameter,2);
 
 
-#if defined(NME_GLES) && defined(GL_KHR_debug) && GL_KHR_debug
+#if defined(GL_KHR_debug) && GL_KHR_debug
+
+#ifdef NME_GLES
+#  define KHR_SUFFIX(NAME) NAME##_KHR
+#  define KHR_FUNCTION_SUFFIX(FUN) FUN##KHR
+#else
+#  define KHR_SUFFIX(NAME) NAME
+#  define KHR_FUNCTION_SUFFIX(FUN) FUN
+#endif
+
 struct DebugMessage
 {
    DebugMessage() : callback(0) { }
@@ -2438,31 +2447,31 @@ static void OnErrorCallback(GLenum source,
    std::string _severity;
 
    switch(source) {
-      case GL_DEBUG_SOURCE_API_KHR:             _source = "API"; break;
-      case GL_DEBUG_SOURCE_WINDOW_SYSTEM_KHR:   _source = "WINDOW SYSTEM"; break;
-      case GL_DEBUG_SOURCE_SHADER_COMPILER_KHR: _source = "SHADER COMPILER"; break;
-      case GL_DEBUG_SOURCE_THIRD_PARTY_KHR:     _source = "THIRD PARTY"; break;
-      case GL_DEBUG_SOURCE_APPLICATION_KHR:     _source = "APPLICATION"; break;
-      case GL_DEBUG_SOURCE_OTHER_KHR:           _source = "UNKNOWN"; break;
+      case KHR_SUFFIX(GL_DEBUG_SOURCE_API):             _source = "API"; break;
+      case KHR_SUFFIX(GL_DEBUG_SOURCE_WINDOW_SYSTEM):   _source = "WINDOW SYSTEM"; break;
+      case KHR_SUFFIX(GL_DEBUG_SOURCE_SHADER_COMPILER): _source = "SHADER COMPILER"; break;
+      case KHR_SUFFIX(GL_DEBUG_SOURCE_THIRD_PARTY):     _source = "THIRD PARTY"; break;
+      case KHR_SUFFIX(GL_DEBUG_SOURCE_APPLICATION):     _source = "APPLICATION"; break;
+      case KHR_SUFFIX(GL_DEBUG_SOURCE_OTHER):           _source = "UNKNOWN"; break;
       default: _source = "UNKNOWN";
    }
 
    switch(type) {
-      case GL_DEBUG_TYPE_ERROR_KHR:               _type = "ERROR" ;break;
-      case GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR_KHR: _type = "DEPRECATED BEHAVIOR" ; break;
-      case GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR_KHR:  _type = "UNDEFINED BEHAVIOR" ; break;
-      case GL_DEBUG_TYPE_PORTABILITY_KHR:         _type = "PORTABILITY" ; break;
-      case GL_DEBUG_TYPE_PERFORMANCE_KHR:         _type = "PERFORMANCE" ; break;
-      case GL_DEBUG_TYPE_OTHER_KHR:               _type = "OTHER" ; break;
-      case GL_DEBUG_TYPE_MARKER_KHR:              _type = "MARKER"; break;
+      case KHR_SUFFIX(GL_DEBUG_TYPE_ERROR):               _type = "ERROR" ;break;
+      case KHR_SUFFIX(GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR): _type = "DEPRECATED BEHAVIOR" ; break;
+      case KHR_SUFFIX(GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR):  _type = "UNDEFINED BEHAVIOR" ; break;
+      case KHR_SUFFIX(GL_DEBUG_TYPE_PORTABILITY):         _type = "PORTABILITY" ; break;
+      case KHR_SUFFIX(GL_DEBUG_TYPE_PERFORMANCE):         _type = "PERFORMANCE" ; break;
+      case KHR_SUFFIX(GL_DEBUG_TYPE_OTHER):               _type = "OTHER" ; break;
+      case KHR_SUFFIX(GL_DEBUG_TYPE_MARKER):              _type = "MARKER"; break;
       default: _type = "UNKNOWN";
    }
 
    switch(severity) {
-      case GL_DEBUG_SEVERITY_HIGH_KHR:         _severity = "HIGH" ; break;
-      case GL_DEBUG_SEVERITY_MEDIUM_KHR:       _severity = "MEDIUM" ; break;
-      case GL_DEBUG_SEVERITY_LOW_KHR:          _severity = "LOW" ; break;
-      case GL_DEBUG_SEVERITY_NOTIFICATION_KHR: _severity = "NOTIFICATION"; break;
+      case KHR_SUFFIX(GL_DEBUG_SEVERITY_HIGH):         _severity = "HIGH" ; break;
+      case KHR_SUFFIX(GL_DEBUG_SEVERITY_MEDIUM):       _severity = "MEDIUM" ; break;
+      case KHR_SUFFIX(GL_DEBUG_SEVERITY_LOW):          _severity = "LOW" ; break;
+      case KHR_SUFFIX(GL_DEBUG_SEVERITY_NOTIFICATION): _severity = "NOTIFICATION"; break;
       default: _severity = "UNKNOWN";
    }
 
@@ -2477,32 +2486,31 @@ static void OnErrorCallback(GLenum source,
 }
 #endif
 
+
 bool nme_gl_debug_message_callback(value inCallback)
 {
-#if defined(NME_GLES) && defined(GL_KHR_debug) && GL_KHR_debug
-   if(GL_KHR_debug)
-   {
-      if (gCurrentDebugMessage)
-         return false;
+#if defined(GL_KHR_debug) && GL_KHR_debug
+   if (gCurrentDebugMessage)
+      return false;
 
-      gCurrentDebugMessage = new DebugMessage();
-      gCurrentDebugMessage->callback = new AutoGCRoot(inCallback);
+   gCurrentDebugMessage = new DebugMessage();
+   gCurrentDebugMessage->callback = new AutoGCRoot(inCallback);
 
-      glEnable(GL_DEBUG_OUTPUT_KHR);
-      glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS_KHR);
-      glDebugMessageCallbackKHR(OnErrorCallback,0);
+   glEnable(KHR_SUFFIX(GL_DEBUG_OUTPUT));
+   glEnable(KHR_SUFFIX(GL_DEBUG_OUTPUT_SYNCHRONOUS));
+   KHR_FUNCTION_SUFFIX(glDebugMessageCallback)(OnErrorCallback,0);
 
-      return true;
-   }
-#endif
+   return true;
+#else
    return false;
+#endif
 }
 DEFINE_PRIME1(nme_gl_debug_message_callback);
 
 
 value nme_gl_debug_message_insert(value inMsg)
 {
-#if defined(NME_GLES) && defined(GL_KHR_debug) && GL_KHR_debug
+#if defined(GL_KHR_debug) && GL_KHR_debug
    DBGFUNC("debugMessageInsert");
    HxString msg = valToHxString(inMsg);
    glDebugMessageInsertKHR( GL_DEBUG_SOURCE_APPLICATION_KHR,
@@ -2662,4 +2670,3 @@ DEFINE_PRIME3v(nme_gl_uniform_block_binding)
 }
 
 extern "C" int nme_oglexport_register_prims() { return 0; }
-

--- a/project/src/opengl/OGLExport.cpp
+++ b/project/src/opengl/OGLExport.cpp
@@ -2407,7 +2407,7 @@ value nme_gl_get_tex_parameter(value inTarget,value inPname)
 DEFINE_PRIM(nme_gl_get_tex_parameter,2);
 
 
-#if defined(GL_KHR_debug) && GL_KHR_debug && (!defined(NME_GLES)|| defined(GL_VERSION_4_3)) &&  !defined(NME_MACOS)
+#if defined(GL_KHR_debug) && GL_KHR_debug && (!defined(NME_GLES)|| defined(GL_VERSION_4_3)) &&  !defined(HX_MACOS)
 #define NME_GL_DEBUG
 #endif
 

--- a/project/src/opengl/OGLExport.cpp
+++ b/project/src/opengl/OGLExport.cpp
@@ -2513,7 +2513,7 @@ bool nme_gl_debug_message_callback(value inCallback)
    glEnable(KHR_SUFFIX(GL_DEBUG_OUTPUT));
    glEnable(KHR_SUFFIX(GL_DEBUG_OUTPUT_SYNCHRONOUS));
    KHR_FUNCTION_SUFFIX(glDebugMessageCallback)(OnErrorCallback,0);
-
+   glDebugMessageControl(GL_DONT_CARE, GL_DONT_CARE, GL_DONT_CARE, 0, NULL, true);
    return true;
 #else
    return false;

--- a/project/src/opengl/OGLExport.cpp
+++ b/project/src/opengl/OGLExport.cpp
@@ -2408,6 +2408,15 @@ DEFINE_PRIM(nme_gl_get_tex_parameter,2);
 
 
 #ifdef GL_KHR_debug
+#ifndef GL_DEBUG_SOURCE_APPLICATION_KHR
+#  define GL_DEBUG_SOURCE_APPLICATION_KHR 0x824A
+#endif
+#ifndef GL_DEBUG_TYPE_OTHER_KHR
+#  define GL_DEBUG_TYPE_OTHER_KHR 0x8251
+#endif
+#ifndef GL_DEBUG_SEVERITY_NOTIFICATION_KHR
+#  define GL_DEBUG_SEVERITY_NOTIFICATION_KHR 0x826B
+#endif
 struct DebugMessage
 {
    DebugMessage() : callback(0) { }
@@ -2425,7 +2434,7 @@ struct DebugMessage
 DebugMessage *gCurrentDebugMessage = 0;
 
 
-static void GL_APIENTRY Callback(GLenum source,
+static void OnErrorCallback(GLenum source,
                                  GLenum type,
                                  GLuint id,
                                  GLenum severity,
@@ -2490,7 +2499,7 @@ bool nme_gl_debug_message_callback( value inCallback )
 
       glEnable(GL_DEBUG_OUTPUT_KHR);
       glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS_KHR);
-      glDebugMessageCallbackKHR( Callback, 0 );
+      glDebugMessageCallbackKHR(OnErrorCallback,0);
 
       return true;
    }

--- a/project/src/opengl/OGLExport.cpp
+++ b/project/src/opengl/OGLExport.cpp
@@ -2493,6 +2493,16 @@ bool nme_gl_debug_message_callback(value inCallback)
    if (gCurrentDebugMessage)
       return false;
 
+   #if !defined(NME_GLES) || (defined(NME_GL_LEVEL) && NME_GL_LEVEL>310)
+   GLint flags;
+   glGetIntegerv(GL_CONTEXT_FLAGS, &flags);
+   if (flags & GL_CONTEXT_FLAG_DEBUG_BIT)
+   {
+      ELOG("Warning, did not set glDebugMessageCallback because not in a gl debug context");
+      return false;
+   }
+   #endif
+
    gCurrentDebugMessage = new DebugMessage();
    gCurrentDebugMessage->callback = new AutoGCRoot(inCallback);
 
@@ -2513,10 +2523,11 @@ value nme_gl_debug_message_insert(value inMsg)
 #if defined(GL_KHR_debug) && GL_KHR_debug
    DBGFUNC("debugMessageInsert");
    HxString msg = valToHxString(inMsg);
-   glDebugMessageInsertKHR( GL_DEBUG_SOURCE_APPLICATION_KHR,
-      GL_DEBUG_TYPE_OTHER_KHR,
+   KHR_FUNCTION_SUFFIX(glDebugMessageInsert)( 
+      KHR_SUFFIX(GL_DEBUG_SOURCE_APPLICATION),
+      KHR_SUFFIX(GL_DEBUG_TYPE_OTHER),
       0,
-      GL_DEBUG_SEVERITY_NOTIFICATION_KHR,
+      KHR_SUFFIX(GL_DEBUG_SEVERITY_NOTIFICATION),
       msg.size(),
       msg.c_str() );
  #endif

--- a/project/src/opengl/OGLExport.cpp
+++ b/project/src/opengl/OGLExport.cpp
@@ -2407,16 +2407,7 @@ value nme_gl_get_tex_parameter(value inTarget,value inPname)
 DEFINE_PRIM(nme_gl_get_tex_parameter,2);
 
 
-#ifdef GL_KHR_debug
-#ifndef GL_DEBUG_SOURCE_APPLICATION_KHR
-#  define GL_DEBUG_SOURCE_APPLICATION_KHR 0x824A
-#endif
-#ifndef GL_DEBUG_TYPE_OTHER_KHR
-#  define GL_DEBUG_TYPE_OTHER_KHR 0x8251
-#endif
-#ifndef GL_DEBUG_SEVERITY_NOTIFICATION_KHR
-#  define GL_DEBUG_SEVERITY_NOTIFICATION_KHR 0x826B
-#endif
+#if defined(NME_GLES) && defined(GL_KHR_debug) && GL_KHR_debug
 struct DebugMessage
 {
    DebugMessage() : callback(0) { }
@@ -2486,9 +2477,9 @@ static void OnErrorCallback(GLenum source,
 }
 #endif
 
-bool nme_gl_debug_message_callback( value inCallback )
+bool nme_gl_debug_message_callback(value inCallback)
 {
-#ifdef GL_KHR_debug
+#if defined(NME_GLES) && defined(GL_KHR_debug) && GL_KHR_debug
    if(GL_KHR_debug)
    {
       if (gCurrentDebugMessage)
@@ -2511,7 +2502,7 @@ DEFINE_PRIME1(nme_gl_debug_message_callback);
 
 value nme_gl_debug_message_insert(value inMsg)
 {
-#ifdef GL_KHR_debug
+#if defined(NME_GLES) && defined(GL_KHR_debug) && GL_KHR_debug
    DBGFUNC("debugMessageInsert");
    HxString msg = valToHxString(inMsg);
    glDebugMessageInsertKHR( GL_DEBUG_SOURCE_APPLICATION_KHR,

--- a/project/src/opengl/OGLExport.cpp
+++ b/project/src/opengl/OGLExport.cpp
@@ -2407,7 +2407,11 @@ value nme_gl_get_tex_parameter(value inTarget,value inPname)
 DEFINE_PRIM(nme_gl_get_tex_parameter,2);
 
 
-#if defined(GL_KHR_debug) && GL_KHR_debug
+#if defined(GL_KHR_debug) && GL_KHR_debug && (!defined(NME_GLES)|| defined(GL_VERSION_4_3))
+#define NME_GL_DEBUG
+#endif
+
+#ifdef NME_GL_DEBUG
 
 #ifdef NME_GLES
 #  define KHR_SUFFIX(NAME) NAME##_KHR
@@ -2489,7 +2493,7 @@ static void OnErrorCallback(GLenum source,
 
 bool nme_gl_debug_message_callback(value inCallback)
 {
-#if defined(GL_KHR_debug) && GL_KHR_debug
+#ifdef NME_GL_DEBUG
    if (gCurrentDebugMessage)
       return false;
 
@@ -2520,7 +2524,7 @@ DEFINE_PRIME1(nme_gl_debug_message_callback);
 
 value nme_gl_debug_message_insert(value inMsg)
 {
-#if defined(GL_KHR_debug) && GL_KHR_debug
+#ifdef NME_GL_DEBUG
    DBGFUNC("debugMessageInsert");
    HxString msg = valToHxString(inMsg);
    KHR_FUNCTION_SUFFIX(glDebugMessageInsert)( 

--- a/project/src/opengl/OGLExtensions.h
+++ b/project/src/opengl/OGLExtensions.h
@@ -180,6 +180,9 @@ OGL_EXT(glDrawArraysInstanced,void,(GLenum mode, GLint first, GLsizei count, GLs
 OGL_EXT(glDrawElementsInstanced,void,(GLenum mode, GLsizei count, GLenum type, const void * indices, GLsizei primcount));
 OGL_EXT(glReadBuffer,void,(GLenum src));
 
+OGL_EXT(glDebugMessageCallback,void,(GLDEBUGPROC callback, const GLvoid *pointer));
+OGL_EXT(glDebugMessageInsert,void,(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *buf));
+
 
 #ifdef DYNAMIC_OGL
 

--- a/project/src/opengl/OGLExtensions.h
+++ b/project/src/opengl/OGLExtensions.h
@@ -180,8 +180,10 @@ OGL_EXT(glDrawArraysInstanced,void,(GLenum mode, GLint first, GLsizei count, GLs
 OGL_EXT(glDrawElementsInstanced,void,(GLenum mode, GLsizei count, GLenum type, const void * indices, GLsizei primcount));
 OGL_EXT(glReadBuffer,void,(GLenum src));
 
+#if defined(GL_KHR_debug) && GL_KHR_debug
 OGL_EXT(glDebugMessageCallback,void,(GLDEBUGPROC callback, const GLvoid *pointer));
 OGL_EXT(glDebugMessageInsert,void,(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *buf));
+#endif
 
 
 #ifdef DYNAMIC_OGL

--- a/project/src/opengl/OGLExtensions.h
+++ b/project/src/opengl/OGLExtensions.h
@@ -180,10 +180,8 @@ OGL_EXT(glDrawArraysInstanced,void,(GLenum mode, GLint first, GLsizei count, GLs
 OGL_EXT(glDrawElementsInstanced,void,(GLenum mode, GLsizei count, GLenum type, const void * indices, GLsizei primcount));
 OGL_EXT(glReadBuffer,void,(GLenum src));
 
-#if defined(GL_KHR_debug) && GL_KHR_debug
 OGL_EXT(glDebugMessageCallback,void,(GLDEBUGPROC callback, const GLvoid *pointer));
 OGL_EXT(glDebugMessageInsert,void,(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *buf));
-#endif
 
 
 #ifdef DYNAMIC_OGL

--- a/project/src/opengl/OGLExtensions.h
+++ b/project/src/opengl/OGLExtensions.h
@@ -182,7 +182,7 @@ OGL_EXT(glReadBuffer,void,(GLenum src));
 
 OGL_EXT(glDebugMessageCallback,void,(GLDEBUGPROC callback, const GLvoid *pointer));
 OGL_EXT(glDebugMessageInsert,void,(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *buf));
-
+OGL_EXT(glDebugMessageControl,void,(GLenum source,GLenum type,GLenum severity,GLsizei count,const GLuint *ids,GLboolean enabled));
 
 #ifdef DYNAMIC_OGL
 

--- a/project/src/sdl2/SDL2Stage.cpp
+++ b/project/src/sdl2/SDL2Stage.cpp
@@ -1824,6 +1824,13 @@ void CreateMainFrame(FrameCreationCallback inOnFrame, int inWidth, int inHeight,
 
    if (opengl)
    {
+      #ifndef HX_MACOS
+      bool glDebug = (inFlags & wfGlDebug) != 0;
+      if(glDebug)
+      {
+         SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_DEBUG_FLAG);          
+      }
+      #endif
       SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 8);
       SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);
       SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 8);

--- a/src/nme/Lib.hx
+++ b/src/nme/Lib.hx
@@ -42,6 +42,7 @@ class Lib
    public static var DEPTH_BUFFER    = Application.DEPTH_BUFFER;
    public static var STENCIL_BUFFER  = Application.STENCIL_BUFFER;
    public static var SINGLE_INSTANCE = Application.SINGLE_INSTANCE;
+   public static var GL_DEBUG        = Application.GL_DEBUG;
 
    public static var initHeight(get, never):Int;
    public static var initWidth(get, never):Int;

--- a/src/nme/app/Application.hx
+++ b/src/nme/app/Application.hx
@@ -52,6 +52,7 @@ class Application
    public inline static var STENCIL_BUFFER  = 0x0400;
    public inline static var SINGLE_INSTANCE = 0x0800;
    public inline static var SCALE_BASE      = 0x1000;
+   public inline static var GL_DEBUG        = 0x10000; //1<<16
 
    public static var nmeFrameHandle:Dynamic = null;
    public static var nmeWindow:Window = null;

--- a/src/nme/gl/GL.hx
+++ b/src/nme/gl/GL.hx
@@ -1605,6 +1605,15 @@ class GL
    }
 
 
+   public static inline function debugMessageCallback(onResult:String->Void):Bool
+   {
+      return nme_gl_debug_message_callback(onResult);
+   }
+
+   public static inline function debugMessageInsert(msg:String):Void
+   {
+      nme_gl_debug_message_insert(msg);
+   }
 
    // Getters & Setters
    private static inline function get_drawingBufferHeight() { return Lib.current.stage.stageHeight; }
@@ -1777,6 +1786,10 @@ class GL
    private static var nme_gl_read_buffer = PrimeLoader.load("nme_gl_read_buffer", "iv");
    private static var nme_gl_tex_image_3d = PrimeLoader.load("nme_gl_tex_image_3d", "iiiiiiiiioiv");
    private static var nme_gl_compressed_tex_image_3d = PrimeLoader.load("nme_gl_compressed_tex_image_3d", "iiiiiiiioiv");
+
+   private static var nme_gl_debug_message_callback = PrimeLoader.load("nme_gl_debug_message_callback", "ob");
+   private static var nme_gl_debug_message_insert = load("nme_gl_debug_message_insert", 1);
+
 
    #else // not (neko||cpp)
 

--- a/templates/haxe/ApplicationMain.hx
+++ b/templates/haxe/ApplicationMain.hx
@@ -188,7 +188,8 @@ class ApplicationMain
          (::WIN_ANTIALIASING:: == 4 ? nme.app.Application.HW_AA_HIRES : 0) |
          (::WIN_ANTIALIASING:: == 2 ? nme.app.Application.HW_AA : 0)|
          (::WIN_SINGLE_INSTANCE:: ? nme.app.Application.SINGLE_INSTANCE : 0) |
-         (::WIN_SCALE_FLAGS:: * nme.app.Application.SCALE_BASE)
+         (::WIN_SCALE_FLAGS:: * nme.app.Application.SCALE_BASE) |
+         (::WIN_GL_DEBUG:: ? nme.app.Application.GL_DEBUG : 0)
          ;
 
 

--- a/tools/nme/src/project/HxParser.hx
+++ b/tools/nme/src/project/HxParser.hx
@@ -104,7 +104,7 @@ class HxParser
             project.window.background = Std.parseInt(value);
             project.localDefines.set("WIN_" + key.toUpperCase(), Std.string(project.window.background));
 
-        case "width", "height", "fps", "vsync", "hardware", "depthBuffer", "stencilBuffer", "alphaBuffer", "singleInstance":
+        case "width", "height", "fps", "vsync", "hardware", "depthBuffer", "stencilBuffer", "alphaBuffer", "singleInstance", "glDebug":
             project.localDefines.set("WIN_" + key.toUpperCase(), value);
             Reflect.setField(project.window, key, value);
 

--- a/tools/nme/src/project/Window.hx
+++ b/tools/nme/src/project/Window.hx
@@ -21,6 +21,7 @@ class Window
    public var ui:String;
    public var singleInstance:Bool;
    public var scaleMode:ScaleMode;
+   public var glDebug:Bool;
 
    public function new()
    {
@@ -43,6 +44,7 @@ class Window
       alphaBuffer = false;
       ui = "";
       singleInstance = true;
+      glDebug = false;
       scaleMode = ScaleNative;
    }
 }


### PR DESCRIPTION
Implements nme.gl.GL.debugMessageCallback and nme.gl.GL.debugMessageInsert

test with

```
package;
import nme.display.Sprite;

class Main extends Sprite {
    public function onError( message:String ){
        trace("GL CALLBACK: "+message);
    }
	
   public function new () {	
        super ();		
        var extensionList = nme.gl.GL.getSupportedExtensions();
        if(Lambda.has(extensionList,"GL_KHR_debug")){
	    	trace("Activating Debug Message Callback");
		   if(nme.gl.GL.debugMessageCallback(onError))
		      nme.gl.GL.debugMessageInsert( "GL DEBUG CALLBACK IS NOW ACTIVATED" );
		    else
	    	      trace("Activating Debug Message Callback Failed");
        }
    }	
}
```

Outputs:
```
Main.hx:31: Activating Debug Message Callback
Main.hx:15: GL CALLBACK: GL DEBUG CALLBACK IS NOW ACTIVATED [in:debugMessageInsert][id:0 type:OTHER severity:NOTIFICATION source:APPLICATION]
```