### PR TITLE
Fixes #602 quickrun is comparing assets

### DIFF
--- a/tools/nme/src/CommandLineTools.hx
+++ b/tools/nme/src/CommandLineTools.hx
@@ -1852,6 +1852,9 @@ class CommandLineTools
       }
 
       project.setCommand(command);
+
+      if(command == 'quickrun')
+         project.skipAssets = true;
    }
 }
 

--- a/tools/nme/src/project/NMEProject.hx
+++ b/tools/nme/src/project/NMEProject.hx
@@ -169,6 +169,7 @@ class NMEProject
 
    // Flags
    public var embedAssets:Bool;
+   public var skipAssets:Bool;
    public var openflCompat:Bool;
    public var debug:Bool;
    public var megaTrace:Bool;
@@ -190,6 +191,7 @@ class NMEProject
    {
       baseTemplateContext = {};
       embedAssets = false;
+      skipAssets = false;
       openflCompat = true;
       iosConfig = new IOSConfig();
       androidConfig = new AndroidConfig();

--- a/tools/nme/src/project/NMMLParser.hx
+++ b/tools/nme/src/project/NMMLParser.hx
@@ -872,7 +872,8 @@ class NMMLParser
                   parseWindowElement(element);
 
                case "assets":
-                  parseAssetsElement(element, extensionPath);
+                  if(!project.skipAssets)
+                     parseAssetsElement(element, extensionPath);
 
                case "watchos":
                   parseWatchOSElement(element, extensionPath);


### PR DESCRIPTION
Fixes https://github.com/haxenme/nme/issues/602.

Intent of "quickrun" command is to just build & run. It appears that skipping the asset compare & copy was missed. This diff properly skips that build step, this speeds up quickrun build by ~20 seconds in my project.