### PR TITLE
[android] ABI defaults, configuration, and multi APK support

### DIFF
--- a/templates/android/PROJ-gradle/app/build.gradle
+++ b/templates/android/PROJ-gradle/app/build.gradle
@@ -17,6 +17,27 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    splits {
+
+        // Configures multiple APKs based on ABI.
+        abi {
+
+            // Enables building multiple APKs per ABI.
+            enable true
+
+            // By default all ABIs are included, so use reset() and include to specify that we only
+            // want APKs for x86 and x86_64.
+
+            // Resets the list of ABIs that Gradle should create APKs for to none.
+            reset()
+
+            // Specifies a list of ABIs that Gradle should create APKs for.
+            include ::ABIS::
+
+            // Specifies that we do not want to also generate a universal APK that includes all ABIs.
+            universalApk false
+        }
+    }
 }
 
 dependencies {

--- a/templates/android/PROJ-gradle/app/build.gradle
+++ b/templates/android/PROJ-gradle/app/build.gradle
@@ -57,3 +57,23 @@ dependencies {
         api project(':::name::')::end::
     }
 }
+
+/* Assigns a different version code for each output APK
+    other than the universal APK. */
+
+ext.abiCodes = [::ABI_CODES::]
+
+import com.android.build.OutputFile
+
+android.applicationVariants.all { variant ->
+    
+    variant.outputs.each { output ->
+        
+        def baseAbiVersionCode = project.ext.abiCodes.get(output.getFilter(OutputFile.ABI))
+        
+        if (baseAbiVersionCode != null) {
+            
+            output.versionCodeOverride = baseAbiVersionCode * 10000 + variant.versionCode
+        }
+    }
+}

--- a/tools/nme/src/platforms/AndroidPlatform.hx
+++ b/tools/nme/src/platforms/AndroidPlatform.hx
@@ -7,7 +7,8 @@ typedef ABI = {
    name: String,
    architecture: Architecture,
    args: Array<String>,
-   libArchSuffix: String
+   libArchSuffix: String,
+   versionCodeScaler: Int
 }
 
 class AndroidPlatform extends Platform
@@ -23,25 +24,29 @@ class AndroidPlatform extends Platform
             name: "armeabi",
             architecture: Architecture.ARMV5,
             args: [],
-            libArchSuffix: "" 
+            libArchSuffix: "",
+            versionCodeScaler: 1
          },
          {
             name: "armeabi-v7a",
             architecture: Architecture.ARMV7,
             args: ["-D", "HXCPP_ARMV7"],
-            libArchSuffix: "-v7"
+            libArchSuffix: "-v7",
+            versionCodeScaler: 2
          },
          {
             name: "arm64-v8a",
             architecture: Architecture.ARM64,
             args: ["-D", "HXCPP_ARM64"],
-            libArchSuffix: "-64"
+            libArchSuffix: "-64",
+            versionCodeScaler: 3
          },
          {
             name: "x86",
             architecture: Architecture.X86,
             args: ["-D", "HXCPP_X86"],
-            libArchSuffix: "-x86"
+            libArchSuffix: "-x86",
+            versionCodeScaler: 4
          }
       ];
 
@@ -219,7 +224,8 @@ class AndroidPlatform extends Platform
       else
          setAntLibraries();
       
-      context.ABIS = Lambda.map(includedABIs(), function(abi:ABI) return '"${abi.name}"').join(',');
+      context.ABIS = Lambda.map(includedABIs(), function(abi:ABI) return '"${abi.name}"').join(', ');
+      context.ABI_CODES = Lambda.map(includedABIs(), function(abi:ABI) return '\'${abi.name}\':${abi.versionCodeScaler}').join(', ');
    }
 
    private function setAntLibraries() {

--- a/tools/nme/src/platforms/AndroidView.hx
+++ b/tools/nme/src/platforms/AndroidView.hx
@@ -1,5 +1,6 @@
 package platforms;
 
+import platforms.AndroidPlatform.ABI;
 import haxe.io.Path;
 import haxe.Template;
 import sys.io.File;
@@ -40,17 +41,11 @@ class AndroidView extends AndroidPlatform
 
       var dbg = project.debug ? "-debug" : "";
 
-      if (buildV5)
-         FileHelper.copyIfNewer(haxeDir + "/cpp/libApplicationMain" + dbg + ".so",
-                sdk + "/libs/armeabi/libApplicationMain.so");
-
-      if (buildV7)
-         FileHelper.copyIfNewer(haxeDir + "/cpp/libApplicationMain" + dbg + "-v7.so",
-                sdk + "/libs/armeabi-v7a/libApplicationMain.so" );
-
-      if (buildX86)
-         FileHelper.copyIfNewer(haxeDir + "/cpp/libApplicationMain" + dbg + "-x86.so",
-                sdk + "/libs/x86/libApplicationMain.so" );
+      Lambda.iter(includedABIs(), function(abi:ABI) {
+         var source = haxeDir + "/cpp/libApplicationMain" + dbg + '${abi.libArchSuffix}.so';
+         var destination = sdk + '/libs/${abi.name}/libApplicationMain.so';
+         FileHelper.copyIfNewer(source, destination);
+      });
    }
 
 

--- a/tools/nme/src/project/NMEProject.hx
+++ b/tools/nme/src/project/NMEProject.hx
@@ -25,6 +25,7 @@ class AndroidConfig
    public var gameActivityBase:String;
    public var gameActivityViewBase:String;
    public var extensions:Map<String,Bool>;
+   public var ABIs:Array<String> = [];
 
    public function new()
    {

--- a/tools/nme/src/project/NMMLParser.hx
+++ b/tools/nme/src/project/NMMLParser.hx
@@ -541,6 +541,9 @@ class NMMLParser
 
                case "gameActivityBase":
                   project.androidConfig.gameActivityBase = value;
+               
+               case "abi":
+                  project.androidConfig.ABIs.push(value);
 
                default:
                   Log.error("Unknown android attribute " + childElement.name);


### PR DESCRIPTION
Fixes #601 
Fixes #604 

This diff changes the following behavior.

1) By default we build "armeabi-v7a", "arm64-v8a", and "x86" instead of just armeabi-v7a.
2) You can override this for faster builds by including one more more `<abi />` elements in your configurations.
```
<android>
    <abi value="armeabi-v7a" />
    <abi value="arm64-v8a" />
    <abi value="x86" />
</android>
```
3) `android -gradle` build produces an APK for each architecture
4) `nme test android -gradle`install the APK by querying your device for it's architecture through adb


 