### PR TITLE
Compile fix Haxe4 (?)

### DIFF
--- a/tools/nme/src/platforms/AndroidPlatform.hx
+++ b/tools/nme/src/platforms/AndroidPlatform.hx
@@ -79,7 +79,7 @@ class AndroidPlatform extends Platform
       Log.verbose("Valid archs: " + project.architectures );
       
       var libDir = getOutputLibDir();
-      var excluded:List<ABI> = Lambda.filter(abis, function(abi:ABI) return project.architectures.indexOf(abi.architecture) == -1);
+      var excluded:Array<ABI> = Lambda.filter(abis, function(abi:ABI) return project.architectures.indexOf(abi.architecture) == -1);
       Lambda.iter(excluded, function(abi:ABI) {
          PathHelper.removeDirectory(libDir + '/${abi.name}');
       });
@@ -110,7 +110,7 @@ class AndroidPlatform extends Platform
       }
    }
 
-   function includedABIs():List<ABI> {
+   function includedABIs():Array<ABI> {
       return Lambda.map(project.architectures, function(architecture:Architecture) {
          return Lambda.find(abis, function(abi:ABI) return abi.architecture == architecture);
       });


### PR DESCRIPTION
Required these to recompile NME on my Haxe version (recent Haxe 4 nightly)

Error was
Compiling nme tool...
src/platforms/AndroidPlatform.hx:82: characters 7-132 : Array<platforms.ABI> should be List<platforms.ABI>
src/platforms/AndroidPlatform.hx:114: lines 114-116 : Array<Null<platforms.ABI>> should be List<platforms.ABI>
Called from Sys::$statics line 1
Called from RunMain::main line 108
Called from RunMain::showMessage line 30
Called from RunMain::setup line 49
Called from RunMain::compileTool line 62
Called from RunMain::run line 75
Uncaught exception - Error running haxe compile.hxml