### PR TITLE
add JNI.createStaticField method

### DIFF
--- a/project/src/android/JNI.cpp
+++ b/project/src/android/JNI.cpp
@@ -989,16 +989,16 @@ struct JNIField : public nme::Object
 };
 
 
-value nme_jni_create_field(value inClass, value inField, value inSig,value inStatic)
+value nme_jni_create_field(value inClass, value inField, value inSig, value inStatic)
 {
-   JNIField *field = new JNIField(inClass,inField,inSig,val_bool(inStatic) );
+   JNIField *field = new JNIField(inClass, inField, inSig, val_bool(inStatic));
    if (field->Ok())
       return ObjectToAbstract(field);
    ELOG("nme_jni_create_field - failed");
    delete field;
    return alloc_null();
 }
-DEFINE_PRIM(nme_jni_create_field,4);
+DEFINE_PRIME4(nme_jni_create_field);
 
 
 value nme_jni_get_static(value inField)
@@ -1009,7 +1009,7 @@ value nme_jni_get_static(value inField)
    value result = field->GetStatic();
    return result;
 }
-DEFINE_PRIM(nme_jni_get_static,1);
+DEFINE_PRIME1(nme_jni_get_static);
 
 
 void nme_jni_set_static(value inField, value inValue)
@@ -1019,7 +1019,7 @@ void nme_jni_set_static(value inField, value inValue)
       return;
    field->SetStatic(inValue);
 }
-DEFINE_PRIM(nme_jni_set_static,2);
+DEFINE_PRIME2v(nme_jni_set_static);
 
 
 value nme_jni_get_member(value inField, value inObject)
@@ -1289,10 +1289,10 @@ struct JNIMethod : public nme::Object
 };
 
 
-value nme_jni_create_method(value inClass, value inMethod, value inSig,value inStatic, value inQuiet)
+value nme_jni_create_method(value inClass, value inMethod, value inSig, value inStatic, value inQuiet)
 {
    bool quiet = val_bool(inQuiet);
-   JNIMethod *method = new JNIMethod(inClass,inMethod,inSig,val_bool(inStatic), quiet );
+   JNIMethod *method = new JNIMethod(inClass, inMethod, inSig, val_bool(inStatic), quiet);
    if (method->Ok())
       return ObjectToAbstract(method);
    if (!quiet)
@@ -1300,7 +1300,7 @@ value nme_jni_create_method(value inClass, value inMethod, value inSig,value inS
    delete method;
    return alloc_null();
 }
-DEFINE_PRIM(nme_jni_create_method,5);
+DEFINE_PRIME5(nme_jni_create_method);
 
 
 value nme_jni_call_static(value inMethod, value inArgs)
@@ -1311,7 +1311,7 @@ value nme_jni_call_static(value inMethod, value inArgs)
    value result =  method->CallStatic(inArgs);
    return result;
 }
-DEFINE_PRIM(nme_jni_call_static,2);
+DEFINE_PRIME2(nme_jni_call_static);
 
 
 value nme_jni_call_member(value inMethod, value inObject, value inArgs)
@@ -1330,7 +1330,7 @@ value nme_jni_call_member(value inMethod, value inObject, value inArgs)
    }
    return method->CallMember(object,inArgs);
 }
-DEFINE_PRIM(nme_jni_call_member,3);
+DEFINE_PRIME3(nme_jni_call_member);
 
 
 

--- a/project/src/android/JNI.cpp
+++ b/project/src/android/JNI.cpp
@@ -1311,7 +1311,7 @@ value nme_jni_call_static(value inMethod, value inArgs)
    value result =  method->CallStatic(inArgs);
    return result;
 }
-DEFINE_PRIME2(nme_jni_call_static);
+DEFINE_PRIM(nme_jni_call_static,2);
 
 
 value nme_jni_call_member(value inMethod, value inObject, value inArgs)
@@ -1330,7 +1330,7 @@ value nme_jni_call_member(value inMethod, value inObject, value inArgs)
    }
    return method->CallMember(object,inArgs);
 }
-DEFINE_PRIME3(nme_jni_call_member);
+DEFINE_PRIM(nme_jni_call_member,3);
 
 
 

--- a/src/nme/JNI.hx
+++ b/src/nme/JNI.hx
@@ -26,7 +26,6 @@ class JNI
 
    static function onCallback(inObj:Dynamic, inFunc:Dynamic, inArgs:Dynamic):Dynamic 
    {
-      //trace("onCallback " + inObj + "," + inFunc + "," + inArgs );
       var field = Reflect.field(inObj, inFunc);
 
       if (field != null)
@@ -65,6 +64,16 @@ class JNI
       return null;
       #end
    }
+   
+	public static function createStaticField(className:String, memberName:String, signature:String):JNIStaticField 
+	{
+		#if android
+		init();
+		return new JNIStaticField(nme_jni_create_field(className, memberName, signature, true));
+		#else
+		return null;
+		#end
+	}
 
    /**
     * Create bindings to a static class method in Java
@@ -130,14 +139,46 @@ class JNI
 
    // Native Methods
    #if android
+   private static var nme_jni_create_field = nme.Loader.load("nme_jni_create_field", 4);
    private static var nme_jni_create_method = nme.Loader.load("nme_jni_create_method", 5);
-   private static var nme_jni_call_member = PrimeLoader.load("nme_jni_call_member", "oooo");
-   private static var nme_jni_call_static = PrimeLoader.load("nme_jni_call_static", "ooo");
+   private static var nme_jni_call_member = nme.Loader.load("nme_jni_call_member", 3);
+   private static var nme_jni_call_static = nme.Loader.load("nme_jni_call_static", 2);
    #else
+   private static var nme_jni_create_field:Dynamic;
    private static var nme_jni_create_method:Dynamic;
    private static var nme_jni_call_member:Dynamic;
    private static var nme_jni_call_static:Dynamic;
    #end
+}
+
+class JNIStaticField 
+{
+	private var field:Dynamic;
+	
+	public function new(field:Dynamic) 
+	{
+		this.field = field;
+	}
+	
+	public function get():Dynamic 
+	{
+		return nme_jni_get_static(field);
+	}
+	
+	public function set(value:Dynamic):Dynamic 
+	{
+		nme_jni_set_static(field, value);
+		return value;
+	}
+	
+	// Native Methods
+	#if android
+	private static var nme_jni_get_static = nme.Loader.load("nme_jni_get_static", 1);
+	private static var nme_jni_set_static = nme.Loader.load("nme_jni_set_static", 2);
+	#else
+	private static var nme_jni_get_static:Dynamic = null;
+	private static var nme_jni_set_static:Dynamic = null;
+	#end
 }
 
 class JNIMethod 
@@ -178,8 +219,8 @@ class JNIMethod
 
    // Native Methods
    #if android
-   private static var nme_jni_call_member = PrimeLoader.load("nme_jni_call_member", "oooo");
-   private static var nme_jni_call_static = PrimeLoader.load("nme_jni_call_static", "ooo");
+   private static var nme_jni_call_member = nme.Loader.load("nme_jni_call_member", 3);
+   private static var nme_jni_call_static = nme.Loader.load("nme_jni_call_static", 2);
    #else
    private static var nme_jni_call_member:Dynamic;
    private static var nme_jni_call_static:Dynamic;

--- a/src/nme/JNI.hx
+++ b/src/nme/JNI.hx
@@ -139,10 +139,10 @@ class JNI
 
    // Native Methods
    #if android
-   private static var nme_jni_create_field = nme.Loader.load("nme_jni_create_field", 4);
-   private static var nme_jni_create_method = nme.Loader.load("nme_jni_create_method", 5);
-   private static var nme_jni_call_member = nme.Loader.load("nme_jni_call_member", 3);
-   private static var nme_jni_call_static = nme.Loader.load("nme_jni_call_static", 2);
+   private static var nme_jni_create_field = PrimeLoader.load("nme_jni_create_field", "ooooo");
+   private static var nme_jni_create_method = PrimeLoader.load("nme_jni_create_method", "oooooo");
+   private static var nme_jni_call_member = PrimeLoader.load("nme_jni_call_member", "oooo");
+   private static var nme_jni_call_static = PrimeLoader.load("nme_jni_call_static", "ooo");
    #else
    private static var nme_jni_create_field:Dynamic;
    private static var nme_jni_create_method:Dynamic;
@@ -173,8 +173,8 @@ class JNIStaticField
 	
 	// Native Methods
 	#if android
-	private static var nme_jni_get_static = nme.Loader.load("nme_jni_get_static", 1);
-	private static var nme_jni_set_static = nme.Loader.load("nme_jni_set_static", 2);
+	private static var nme_jni_get_static = PrimeLoader.load("nme_jni_get_static", "oo");
+	private static var nme_jni_set_static = PrimeLoader.load("nme_jni_set_static", "oov");
 	#else
 	private static var nme_jni_get_static:Dynamic = null;
 	private static var nme_jni_set_static:Dynamic = null;
@@ -219,8 +219,8 @@ class JNIMethod
 
    // Native Methods
    #if android
-   private static var nme_jni_call_member = nme.Loader.load("nme_jni_call_member", 3);
-   private static var nme_jni_call_static = nme.Loader.load("nme_jni_call_static", 2);
+   private static var nme_jni_call_member = PrimeLoader.load("nme_jni_call_member", "oooo");
+   private static var nme_jni_call_static = PrimeLoader.load("nme_jni_call_static", "ooo");
    #else
    private static var nme_jni_call_member:Dynamic;
    private static var nme_jni_call_static:Dynamic;


### PR DESCRIPTION
Hello!
Our team is working on porting our project from old OpenFl legacy fork to NME (since it can generate 64-bit apk files). And some of our native extensions are using JNI.createStaticField() method, which is missing in Haxe part of NME (but cpp part of NME has it). So i thought it would be nice to add it back to NME again