### PR TITLE
Add missing decref to OpenSLSound destructor, to prevent memory leak.

### DIFF
--- a/project/src/audio/OpenSlSound.cpp
+++ b/project/src/audio/OpenSlSound.cpp
@@ -218,6 +218,8 @@ public:
    ~OpenSlSourceChannel()
    {
       stop();
+      if (soundObject) 
+         soundObject->DecRef();
    }
 
    void play()


### PR DESCRIPTION
Simple fix to make sure sounds get their reference count decremented when OpenSL channels finish (otherwise they hung around in memory forever). This has been live on a large user base for 6 months or so and has helped reduce our crash rate pretty significantly so think it's good to go.