### PR TITLE
Add null checks around all uses of bqPlayerPlay 

### DIFF
--- a/project/src/audio/OpenSlSound.cpp
+++ b/project/src/audio/OpenSlSound.cpp
@@ -142,7 +142,7 @@ public:
          case 22050: slRate = SL_SAMPLINGRATE_22_05; break;
          case 44100: slRate = SL_SAMPLINGRATE_44_1; break;
       }
-
+      
       const SLInterfaceID ids[] = {iidVolume};
       const SLboolean req[] = {SL_BOOLEAN_FALSE};
       if ((*engineEngine)->CreateOutputMix(engineEngine, &outputMixObject, 1, ids, req)==SL_RESULT_SUCCESS &&
@@ -181,7 +181,6 @@ public:
          // create audio player
          const SLInterfaceID ids1[] = {iidAndroidSampleBuffer, iidVolume};
          const SLboolean req1[] = {SL_BOOLEAN_TRUE};
-          
          if ( (*engineEngine)->CreateAudioPlayer(engineEngine, &bqPlayerObject, &audioSrc, &audioSnk, 2, ids1, req1)==SL_RESULT_SUCCESS &&
               (*bqPlayerObject)->Realize(bqPlayerObject, SL_BOOLEAN_FALSE) == SL_RESULT_SUCCESS &&
               (*bqPlayerObject)->GetInterface(bqPlayerObject, iidPlay, &bqPlayerPlay)==SL_RESULT_SUCCESS  &&
@@ -284,9 +283,12 @@ public:
       if (bqPlayerObject)
       {
          SLuint32 state = SL_PLAYSTATE_PLAYING;
-         (*bqPlayerPlay)->SetPlayState(bqPlayerPlay, SL_PLAYSTATE_STOPPED);
-         while(state != SL_PLAYSTATE_STOPPED)
-            (*bqPlayerPlay)->GetPlayState(bqPlayerPlay, &state);
+         if (bqPlayerPlay) 
+         {
+            (*bqPlayerPlay)->SetPlayState(bqPlayerPlay, SL_PLAYSTATE_STOPPED);
+            while(state != SL_PLAYSTATE_STOPPED)
+                  (*bqPlayerPlay)->GetPlayState(bqPlayerPlay, &state);
+         }
          (*bqPlayerObject)->Destroy(bqPlayerObject);
          bqPlayerObject = 0;
          bqPlayerPlay = 0;
@@ -317,7 +319,10 @@ public:
       if (shouldPlay)
       {
          LOG_SOUND(" -> pause");
-         (*bqPlayerPlay)->SetPlayState(bqPlayerPlay, SL_PLAYSTATE_PAUSED);
+        if (bqPlayerPlay) 
+        { 
+           (*bqPlayerPlay)->SetPlayState(bqPlayerPlay, SL_PLAYSTATE_PAUSED);
+        }
       }
    }
    
@@ -328,7 +333,10 @@ public:
       if (shouldPlay)
       {
          LOG_SOUND(" -> play");
-         (*bqPlayerPlay)->SetPlayState(bqPlayerPlay, SL_PLAYSTATE_PLAYING);
+         if (bqPlayerPlay) 
+         { 
+           (*bqPlayerPlay)->SetPlayState(bqPlayerPlay, SL_PLAYSTATE_PLAYING);
+         }
       }
    }
   


### PR DESCRIPTION
Prevent dereferencing null in situations where the player doesn’t initialise correctly. This has been live in our codebase for 6 months+ and has helped to significantly reduce our Android crash rate. 

I'm still unclear why it was happening in the first place, but better safe than sorry. 

Fixes #527.