### PR TITLE
Android - keep screen on

### DIFF
--- a/templates/android/PROJ/src/org/haxe/nme/GameActivity.java
+++ b/templates/android/PROJ/src/org/haxe/nme/GameActivity.java
@@ -150,6 +150,7 @@ implements SensorEventListener
       mAssets = getAssets();
       requestWindowFeature(Window.FEATURE_NO_TITLE);
       getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN, WindowManager.LayoutParams.FLAG_FULLSCREEN);
+      getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
       ::end::
 
       _sound = new Sound(mContext);


### PR DESCRIPTION
We were asked to make sure the screen didn't go off during gameplay on Android. Whether or not this is desirable default behaviour, I'm unsure, however it does seem to be consistent with the iOS target, which seems sensible.