### PR TITLE
Add range check for Tilesheet's getTileRect() method

### DIFF
--- a/src/nme/display/Tilesheet.hx
+++ b/src/nme/display/Tilesheet.hx
@@ -52,6 +52,11 @@ class Tilesheet
 
    public function getTileRect(index:Int, ?result:Rectangle):Rectangle
    {
+      if (tileCount <= index)
+      {
+        return null;
+      }
+      
       if (result == null)
       {
         result =  new Rectangle();


### PR DESCRIPTION
If you specify `index` that is not less than `tileCount` then application will crash since there is no range checks in `GetTile()` method in `Tilesheet.h`