### PR TITLE
More MacOS font folders

### DIFF
--- a/project/src/common/FreeType.cpp
+++ b/project/src/common/FreeType.cpp
@@ -527,7 +527,7 @@ const char *fontFolders[] = { "/System/Library/Fonts/CoreAddition/", "/System/Li
 			      "/System/Library/Fonts/Extra/", "/System/Library/Fonts/Cache/", 0 };
 #else
 //#define FONT_BASE "/Library/Fonts/"
-const char *fontFolders[] = { "/Library/Fonts/", 0 };
+const char *fontFolders[] = { "/System/Library/Fonts", "/System/Library/Fonts/Supplemental/", "/Library/Fonts/", 0 };
 #endif
 
    const char **testFolder = fontFolders;
@@ -1388,7 +1388,7 @@ void nme_font_iterate_device_fonts(value inFunc)
 	    "/System/Library/Fonts/AppFonts/", "/System/Library/Fonts/LanguageSupport/", "/System/Library/Fonts/Watch/",
 	    "/System/Library/Fonts/Extra/", "/System/Library/Fonts/Cache/"
          #elif defined(__APPLE__)
-            "/Library/Fonts/"
+            "/System/Library/Fonts", "/System/Library/Fonts/Supplemental/", "/Library/Fonts/"
          #elif defined(HX_WINDOWS)
            win_path
          #else


### PR DESCRIPTION
This PR fix for https://github.com/haxenme/nme/issues/654 issue

Additional description:
Installed latest MacOS and lost default fonts _serif, _sans etc. Discovered that fonts moved to /System/Library/Fonts/Supplemental/ folder. Not sure if this unique to my case or on new mac fonts relocated. Can anybody confirm this?