### PR TITLE
[android] Make gradle the default android build tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ project/src/emscripten/_serif.cpp
 all_objs
 *.pdb
 *.hash
+
+# OSX
+*.DS_Store

--- a/README.md
+++ b/README.md
@@ -46,5 +46,5 @@ Browse the [sample projects](https://github.com/haxenme/nme/tree/master/samples)
 ### Android
 
 * NDK(r20) Recommended
-* `haxelib run nme build android -gradle` builds all APKs
-* `haxelib run nme test android -gradle` only builds the APK required for the running devices architecture 
+* `haxelib run nme build android` builds all APKs
+* `haxelib run nme test android` only builds the APK required for the running devices architecture 

--- a/samples/Accelerometer/Source/README.md
+++ b/samples/Accelerometer/Source/README.md
@@ -1,4 +1,4 @@
-haxelib run nme test android -gradle && adb logcat
+haxelib run nme test android && adb logcat
 
 Expected x,y,z values output as a trace.
 

--- a/samples/AppLinks/README.md
+++ b/samples/AppLinks/README.md
@@ -9,7 +9,7 @@ http://www.example.com/gizmos
 
 Perhaps via gmail or sms.
 
-3) nme test android -gradle
+3) nme test android
 4) Click the link in SMS or gmail
 
 Expect: 

--- a/tools/nme/src/CommandLineTools.hx
+++ b/tools/nme/src/CommandLineTools.hx
@@ -29,7 +29,7 @@ class CommandLineTools
    public static var nme(default,null):String;
    public static var home:String;
    public static var sys:SysProxy;
-   public static var gradle:Bool = false;
+   public static var gradle:Bool = true;
    public static var quick:Bool = false;
    public static var fat:Bool = false;
    public static var browser:String = null;
@@ -451,8 +451,8 @@ class CommandLineTools
             args.push("-debug");
          if (!toolkit)
             args.push("-notoolkit");
-         if (gradle)
-            args.push("-gradle");
+         if (!gradle)
+            args.push("-ant");
          if (browser!=null)
          {
             args.push("-browser");
@@ -1702,10 +1702,10 @@ class CommandLineTools
             else if (argument == "-32") 
                project.architectures.push(Architecture.X86);
 
-            else if (argument=="-gradle" || argument=="-Dgradle")
+            else if (argument=="-ant" || argument=="-Dant")
             {
-               gradle = true;
-               project.haxedefs.set("gradle", "1");
+               gradle = false;
+               project.haxedefs.remove("gradle");
             }
             else if (argument=="-q" || argument=="-quick")
             {

--- a/tools/nme/src/project/NMEProject.hx
+++ b/tools/nme/src/project/NMEProject.hx
@@ -346,6 +346,7 @@ class NMEProject
          case "android":
             target = Platform.ANDROID;
             targetFlags.set("android", "");
+            haxedefs.set("gradle", "1");
 
          case "androidsim":
             target = Platform.ANDROID;


### PR DESCRIPTION
Fixes #655, if you still need ant then pass a `-ant` flag to NME.

Testing:

1. Rebuild the tools
2. Build a sample with `haxelib run nme test android`
Verified output is in gradle. (/)