### PR TITLE
"haxelib path" can return empty lines

### DIFF
--- a/tools/build/Builder.hx
+++ b/tools/build/Builder.hx
@@ -14,7 +14,7 @@ class Builder extends hxcpp.Builder
    }
 
    override public function wantWindows64() { return true; }
-   override public function wantWindowsArm64() { return true; }
+   override public function wantWindowsArm64() { return false; }
 
    override public function showUsage(inShowSpecifyMessage:Bool)
    {

--- a/tools/nme/src/project/Haxelib.hx
+++ b/tools/nme/src/project/Haxelib.hx
@@ -33,6 +33,10 @@ class Haxelib
          var soFar = new Array<String>();
          for(line in paths)
          {
+            if (StringTools.trim(line).length == 0) // "haxelib path ..." can return blank lines
+            {
+               continue;
+            }
             if (line.substr(0,2)=="-D")
             {
                var lib = line.substr(3).split("=")[0];


### PR DESCRIPTION
the build tool (that generates the .hxml) uses "haxelib path {lib}" to get info about the any haxelibs, this can return blanks lines, eg:

```
C:\Users\ianha>haxelib path haxeui-core

C:\Work\HaxeUI\haxeui-core\
-D haxeui-core=1.4.0

C:\Users\ianha>
```

This in turn then causes the tool to create empty `-cp` elements that stops the compiler from working - this change skips empty lines read from stdin (and also fixes: https://github.com/haxenme/nme/issues/706)