### PR TITLE
Initial mobile mouse support

### DIFF
--- a/templates/ios/UIStageView.mm
+++ b/templates/ios/UIStageView.mm
@@ -2149,7 +2149,28 @@ bool nmeIsMain = true;
    [super didMoveToParentViewController:parent];
 }
 
+- (void)viewDidLoad
+{
+    [super viewDidLoad];
 
+    if (@available(iOS 13, *)) {
+        UIHoverGestureRecognizer *hover = [[UIHoverGestureRecognizer alloc] initWithTarget:self action:@selector(hover:)];
+        [self.view addGestureRecognizer:hover];
+    }
+}
+
+- (void)hover:(UIHoverGestureRecognizer *)gestureRecognizer API_AVAILABLE(ios(13))
+{
+    CGPoint p = [gestureRecognizer locationInView:self.view];
+
+    if (gestureRecognizer.state == UIGestureRecognizerStateChanged)
+    {
+        Event mouse(etMouseMove, p.x*nmeStage->nmeView->dpiScale, p.y*nmeStage->nmeView->dpiScale);
+        //mouse.flags |= efLeftDown;
+        //mouse.flags |= efPrimaryTouch;
+        nmeStage->OnEvent(mouse);
+    }
+}
 
 - (void)viewDidAppear:(BOOL)animated
 {


### PR DESCRIPTION
I am using Bluetooth mouse for iPad. Works on ios, ipados 13+. Could be useful for somebody too.  Android mouse move can be easily updated with:
                case MotionEvent.ACTION_HOVER_MOVE:
                    //TODO process the mouse hover movement...
                    //Log.v("MainView","ACTION_HOVER_MOVE X:" + event.getRawX() + " Y:" + event.getRawY());
                    final MainView me1 = this;
                    final float x1 = event.getRawX();
                    final float y1 = event.getRawY();
                    queueEvent(new Runnable(){
                        public void run() { me1.HandleResult(NME.onMouseMove(x1,y1) ); }
                    });
                    return true; 
Mobile devices getting mouse friendly.