### PR TITLE
iphone app allow background music to continue to play

### DIFF
--- a/templates/ios/UIStageView.mm
+++ b/templates/ios/UIStageView.mm
@@ -11,7 +11,7 @@
 #import <QuartzCore/CADisplayLink.h>
 #import <CoreMotion/CMMotionManager.h>
 #import <MediaPlayer/MediaPlayer.h>
-
+#import <AVFoundation/AVFoundation.h>
 
 ::if NME_METAL::
 #define NME_METAL

--- a/templates/ios/UIStageView.mm
+++ b/templates/ios/UIStageView.mm
@@ -2266,6 +2266,10 @@ bool nmeIsMain = true;
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
    APP_LOG(@"application start");
+   
+   //audio from other apps mixes with your audio
+   [[AVAudioSession sharedInstance] setCategory:AVAudioSessionCategoryAmbient error:nil];
+   
    UIWindow *win = [[UIWindow alloc] initWithFrame:[[UIScreen mainScreen] bounds]];
    window = win;
    [window makeKeyAndVisible];


### PR DESCRIPTION
Issue description:
https://stackoverflow.com/questions/14122363/iphone-app-allow-background-music-to-continue-to-play

On older ios nme app can cancel background music when you open it, on new ios it will stop music when you close app.