### PR TITLE
Fix android (Work in Progress)

### DIFF
--- a/project/Build.xml
+++ b/project/Build.xml
@@ -441,7 +441,7 @@
             <vflag name="-framework" value="OpenGL" />
             <vflag name="-framework" value="AppKit" />
             <vflag name="-framework" value="OpenAL"/>
-            <vflag name="-framework" value="AVFoundation" if="NME_CAMERA"/>
+            <vflag name="-framework" value="AVFoundation" />
             <vflag name="-framework" value="CoreMedia" if="NME_CAMERA"/>
             <vflag name="-framework" value="CoreVideo" if="NME_CAMERA"/>
          </section>

--- a/project/ToolkitBuild.xml
+++ b/project/ToolkitBuild.xml
@@ -99,7 +99,8 @@
 
    <set name="NME_OPENAL" value="1" if="emscripten" />
 
-   <set name="NME_CAMERA" value="1" unless="emscripten||winrt" />
+   <!--   <set name="NME_CAMERA" value="1" unless="emscripten||winrt" />-->
+   <set name="NME_NO_CAMERA" value="1" />
 
    <!-- Built relative to "bin" -->
    <set name="NME_ROOT" value="" />
@@ -561,8 +562,8 @@
             <vflag name="-framework" value="OpenGL" if="NME_OGL" />
             <vflag name="-framework" value="AppKit" />
             <vflag name="-framework" value="OpenAL"/>
-            <vflag name="-framework" value="AVFoundation" if="NME_CAMERA"/>
-            <vflag name="-framework" value="CoreMedia" if="NME_CAMERA"/>
+            <vflag name="-framework" value="AVFoundation" />
+            <vflag name="-framework" value="CoreMedia" />
             <vflag name="-framework" value="CoreVideo" if="NME_CAMERA"/>
             <lib name="-liconv" />
          </section>

--- a/project/include/NMEThread.h
+++ b/project/include/NMEThread.h
@@ -2,6 +2,8 @@
 #define NME_THREAD_H
 
 #include <hx/Thread.h>
+#include <hxcpp.h>
+#include <hx/StdLibs.h>
 
 #ifndef HX_WINDOWS
 #include <pthread.h>
@@ -51,7 +53,7 @@ extern int GetWorkerCount();
 inline int GetNextTask()
 {
    #ifdef NME_WORKER_THREADS
-   return HxAtomicInc(&gTaskId);
+   return _hx_atomic_inc(&gTaskId);
    #else
    return gTaskId++;
    #endif

--- a/project/src/audio/OpenALSound.cpp
+++ b/project/src/audio/OpenALSound.cpp
@@ -14,6 +14,8 @@
 #include <NMEThread.h>
 #include <unistd.h>
 #include <sys/time.h>
+#include <hxcpp.h>
+#include <hx/StdLibs.h>
 
 typedef unsigned char uint8;
 

--- a/project/src/audio/OpenSlSound.cpp
+++ b/project/src/audio/OpenSlSound.cpp
@@ -8,6 +8,8 @@
 #include "Audio.h"
 #include <NMEThread.h>
 #include <dlfcn.h>
+#include <hxcpp.h>
+#include <hx/StdLibs.h>
 //#include <unistd.h>
 //#include <sys/time.h>
 
@@ -402,13 +404,13 @@ public:
 
    void onBufferDone()
    {
-      HxAtomicDec(&activeBuffers);
+      _hx_atomic_dec(&activeBuffers);
    }
 
 
    std::vector<unsigned char> &allocBuffer()
    {
-      HxAtomicInc(&activeBuffers);
+      _hx_atomic_inc(&activeBuffers);
       LOG_SOUND("Writing to buffer %d/%d", writeBuffer, activeBuffers);
       std::vector<unsigned char> & result = sampleBuffer[writeBuffer];
       writeBuffer = !writeBuffer;
@@ -672,7 +674,7 @@ public:
 
    void onBufferDone()
    {
-      HxAtomicDec(&activeBuffers);
+      _hx_atomic_dec(&activeBuffers);
       LOG_SOUND("onBufferDone -> %d", activeBuffers);
       if (!priming)
          streamBuffer();

--- a/project/src/common/ExternalInterface.cpp
+++ b/project/src/common/ExternalInterface.cpp
@@ -294,7 +294,7 @@ extern "C" void InitIDs()
    _tile_rect = FRect(0, 0, 1, 1);
 
    #ifndef NME_NO_CAMERA
-   InitCamera();
+   //   InitCamera();
    #endif
 }
 

--- a/project/src/common/Thread.cpp
+++ b/project/src/common/Thread.cpp
@@ -1,4 +1,6 @@
 #include <NMEThread.h>
+#include <hxcpp.h>
+#include <hx/StdLibs.h>
 
 namespace nme
 {
@@ -90,7 +92,7 @@ static THREAD_FUNC_TYPE SThreadLoop( void *inInfo )
 
       // Signal
       sThreadActive[threadId] = false;
-      if (HxAtomicDec(&gActiveThreads)==1)
+      if (_hx_atomic_dec(&gActiveThreads)==1)
       {
          #ifdef NME_PTHREADS
          NmeAutoMutex lock(sThreadPoolLock);

--- a/templates/android/PROJ-gradle/app/src/main/AndroidManifest.xml
+++ b/templates/android/PROJ-gradle/app/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
       <activity
         android:name="MainActivity"
         android:label="::APP_TITLE::"
+        android:exported="true"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize"::if (WIN_ORIENTATION!=""):: android:screenOrientation="::WIN_ORIENTATION::"::end::
       ::foreach appActivity:: ::__current__:: ::end::
        >


### PR DESCRIPTION
This diff is in progress, do not merge.

With these tweaks I'm able to launch `samples/DisplayingABitmap` on an Android Studio simulator, but upon start it crashes with this.

```
--------- beginning of crash
01-27 18:30:10.859  8291  8291 E AndroidRuntime: FATAL EXCEPTION: main
01-27 18:30:10.859  8291  8291 E AndroidRuntime: Process: io.nme.samples.displayingabitmap, PID: 8291
01-27 18:30:10.859  8291  8291 E AndroidRuntime: java.lang.UnsatisfiedLinkError: dlopen failed: cannot locate symbol "png_do_expand_palette_rgb8_neon" referenced by "/data/app/~~atlhMAHiK7-WgE5zvX-tCQ==/io.nme.samples.displayingabitmap-isjSpgoxmObtOb0rKbDRpQ==/lib/arm64/libApplicationMain.so"...
01-27 18:30:10.859  8291  8291 E AndroidRuntime: 	at java.lang.Runtime.loadLibrary0(Runtime.java:1077)
01-27 18:30:10.859  8291  8291 E AndroidRuntime: 	at java.lang.Runtime.loadLibrary0(Runtime.java:998)
01-27 18:30:10.859  8291  8291 E AndroidRuntime: 	at java.lang.System.loadLibrary(System.java:1661)
01-27 18:30:10.859  8291  8291 E AndroidRuntime: 	at org.haxe.HXCPP.run(HXCPP.java:12)
01-27 18:30:10.859  8291  8291 E AndroidRuntime: 	at org.haxe.nme.GameActivity.onCreate(GameActivity.java:189)
01-27 18:30:10.859  8291  8291 E AndroidRuntime: 	at android.app.Activity.performCreate(Activity.java:8290)
01-27 18:30:10.859  8291  8291 E AndroidRuntime: 	at android.app.Activity.performCreate(Activity.java:8269)
01-27 18:30:10.859  8291  8291 E AndroidRuntime: 	at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1384)
01-27 18:30:10.859  8291  8291 E AndroidRuntime: 	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3657)
01-27 18:30:10.859  8291  8291 E AndroidRuntime: 	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3813)
01-27 18:30:10.859  8291  8291 E AndroidRuntime: 	at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:101)
01-27 18:30:10.859  8291  8291 E AndroidRuntime: 	at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:135)
01-27 18:30:10.859  8291  8291 E AndroidRuntime: 	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
01-27 18:30:10.859  8291  8291 E AndroidRuntime: 	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2308)
01-27 18:30:10.859  8291  8291 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:106)
01-27 18:30:10.859  8291  8291 E AndroidRuntime: 	at android.os.Looper.loopOnce(Looper.java:201)
01-27 18:30:10.859  8291  8291 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:288)
01-27 18:30:10.859  8291  8291 E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:7898)
01-27 18:30:10.859  8291  8291 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
01-27 18:30:10.859  8291  8291 E AndroidRuntime: 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
01-27 18:30:10.859  8291  8291 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
01-27 18:30:10.861   580   593 W ActivityTaskManager:   Force finishing activity io.nme.samples.displayingabitmap/.MainActivity
```